### PR TITLE
updated debugging page for mac, and events page with updated example

### DIFF
--- a/docs/trex_debugging.md
+++ b/docs/trex_debugging.md
@@ -3,38 +3,70 @@ title: Remote Debugging of JavaScript and HTML
 layout: docs
 ---
 
-A dashboard extension embeds a web page and runs a Chromium-based browser inside of Tableau. Fortunately, you can debug this embedded web browser using the remote debugging abilities built-in to Chromium.
+A dashboard extension embeds a web page and runs a Chromium-based browser inside of Tableau. Fortunately, you can debug this embedded web browser using the remote debugging abilities built into Chromium.
 
-## Setup
-### Tableau
-* Inside Tableau desktop, drag out an Add-In onto a dashboard.
-* Find the dropdown caret in the upper left or right corner of the add-in control
-* After enabling debugging, click Reload to reinitialize the browser.
+---
+**In this section**
+
+* TOC
+{:toc}
+
+ 
+## Set up Tableau for debugging (Windows)
+
+1. Start Tableau and drag an extension onto the dashboard.
+2. Select the extension in the dashboard. 
+3. Click the **More Options** button in the upper-left or upper-right corner of the extension. Click **Debug Options** > **Enable Debugging**.
+4. After enabling debugging, select **Debug Options** > **Reload** to reinitialize the browser. You might need to stop and restart Tableau for the settings to take effect. 
 
 ![Enable and reload]({{site.baseurl}}/assets/TcNTYA9566.gif)
 
-Once you've done these steps, debugging will be enabled for all add-ins until it's turned off.
 
-### Chromium Browser
-In order to actually do any debugging, you'll need to use a Chromium-based browser. You can use a normal install of Chrome, but because of some version incompatibilities in the debugging protocol, we recommend using [this specific version of Chromium](https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Win%2F352221%2Fchrome-win32.zip?generation=1443839123039000&alt=media) which matches the version of the browser running inside Tableau (just download and unzip).
+After you've done these steps, debugging will be enabled for all extensions until you turn it off.
 
-## Debugging Using Chrome/Chromium
-Once you have all the setup steps completed, simply go to [http://localhost:8696](http://localhost:8696) which will bring up the page selector UI. Pick the add-in you want to debug from this page and debug just like normal.
+
+## Set up Tableau for debugging (macOS)
+
+If you are using Tableau Desktop on macOS, you need to open a Terminal window and run a command to enable debugging. 
+
+1. Open a terminal window. 
+2. Start Tableau using the following command:
+
+   ```
+   open /Applications/Tableau\ Desktop\ near.app --args --remote-debugging-port=8696
+   ```
+
+**Note:** The remote debuggging port (for example, `8696`) must match the port address you use with Chromium for debugging. This is not the HTTP port that you are using to host your extension. 
+
+
+## Download the Chromium Browser
+In order to actually do any debugging, you'll need to use a Chromium-based browser. You can use a normal install of Chrome, but because of some version incompatibilities in the debugging protocol, we recommend using build 47.0.2526.0 of Chromium, which matches the version of the browser running inside Tableau (just download and unzip the file).
+* [Chromium for Windows (47.0.2526.0)](https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Win%2F352221%2Fchrome-win32.zip?generation=1443839123039000&alt=media) | 
+* [Chromium for macOS (47.0.2526.0)](https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Mac%2F352221%2Fchrome-mac.zip?generation=1443838516381000&alt=media) 
+
+
+## Debugging using Chrome/Chromium
+After you have installed the Chromium browser and have enabled debugging in Tableau, you can start debugging your extension. 
+1. Start Tableau and open the dashboard with the extension you want to debug. 
+2. Start Chromium and set the URL to [`http://localhost:8696`](http://localhost:8696)  
+   This will bring up the page selector UI. 
+3. Pick the extension you want to debug from this page, and debug just like you would any other web application.
 
 ![Remote Debugging]({{site.baseurl}}/assets/UsWdJEnOiR.gif)
 
 ### Debugging Loading / Initialization Issues
-It can be difficult to hit breakpoints which occur during the loading of your page due to the remote debugging process. To help with this, we've included a menu option which causes your add-in to load until you trigger it to.
-* In the Debug Options dropdown menu, select Pause Before Loading
-* Reload your add-in
-* In Chromium, go to the debugging homepage ([http://localhost:8696](http://localhost:8696)). Click the fist item listed (it will be completely blank but still visible) to attach to the browser instance.
-* On the Sources tab, Find 'Event Listener Breakpoints' and enabled the 'Script' > 'Script First Statement' breakpoint.
-* Back in Tableau, click the add-in zone to load your page.
-* The debugger will pause each time the first statement of a script runs allowing you to debug the startup process
+It can be difficult to hit breakpoints which occur during the loading of your page due to the remote debugging process. To help with this, we've included a menu option which causes your extension to wait to load until you trigger it to.
+1. In the **Debug Options** dropdown menu, select **Pause Before Loading**.
+2. Reload your extension (**Debug Options** > **Reload**)
+3. In Chromium, go to the debugging homepage ([http://localhost:8696](http://localhost:8696)). 
+4. To attach to the browser instance, click the frist item listed (it will be completely blank, but it is really there, and the selection is visible when you click on it). 
+4. Click the **Sources** tab in Chromium, under **Event Listener Breakpoints**, click **Script** and enable the **Script First Statement** breakpoint.
+5. Back in Tableau, click the extension zone to load your page.
+6. The debugger will pause each time the first statement of a script runs allowing you to debug the startup process
 
 ![Startup Debugging]({{site.baseurl}}/assets/foucUWBiUJ.gif)
 
 ## Known Issues
 #### Refreshed Page Fails
-Unfortunately due to a bug with our embedded browser, refreshing a loaded page doesn't properly setup the communication between Tableau and the add-in. This means that trigger a page reload will cause your add-in to stop working. It's important to note that the 'Reload' menu option actually tears down and recreates the Browser control which means you'll need to establish a new debugging sessions whenever you click that.
+Unfortunately, due to a bug with our embedded browser, refreshing a loaded page doesn't properly setup the communication between Tableau and the extension. This means that trigger a page reload will cause your extension to stop working. It's important to note that the **Reload** menu option actually tears down and re-creates the browser control, which means you'll need to establish a new debugging sessions whenever you click **Reload**.
 

--- a/docs/trex_events.md
+++ b/docs/trex_events.md
@@ -13,18 +13,23 @@ Listening to an event is done by calling the `addEventListener(type, callback)` 
 ## Add an event listener  
 
 1. Get the sheet object that you want to observe (this could be an individual sheet, or it could be the whole dashboard). 
-2. Get the event listener manager for the sheet object, by calling `getEventListenerManager()`. 
-3. Add the event listener by calling `addEventListener` and specifying the name of the event and the callback method to call. The name of the event must be one of the supported types defined in the `TableauEventName` enumeration. The callback method must handle the event object raised.
+2. Add the event listener by calling `addEventListener` and specifying the name of the event and the callback method to call. The name of the event must be one of the supported types defined in the `TableauEventName` enumeration. The callback method must handle the event object raised.
+
 
 > **Note:** For information about the Tableau Extensions API, see <a href="{{ site.baseurl }}/docs/index.html" target="_blank">API Reference</a>. 
 
 
 ### Example 
 
-In most cases, you can create an event listener by chaining the methods to the sheet object. In the following example, the name of the event is `tableau.TableauEventName.MARKS_SELECTION` or `marksselection`. When a user selects or deselects marks in the sheet, a `MarksEvent` is raised, and the callback method `selectionChangedEvent` is called to handle the event. 
+In most cases, you can create an event listener by chaining the methods to the sheet object. In the following example, the name of the event is `tableau.TableauEventType.FilterChanged` or a `FilterChanged` event. When a user changes filters in the sheet, a `FilterChanged` is raised, and the callback method `filterChangedHandler` is called to handle the event. 
 
 ```javascript   
-sheet.getEventListenerManager().addEventListener(tableau.TableauEventName.MarksSelection, selectionChangedEvent);
+// ...
+// Add filter event to each worksheet.  AddEventListener returns a function that will
+// remove the event listener when called.
+   let unregisterHandlerFunction = worksheet.addEventListener(tableau.TableauEventType.FilterChanged, filterChangedHandler);
+   unregisterHandlerFunctions.push(unregisterHandlerFunction);
+// ...
 ```  
 
-For more information, check out the example extension, SelectedMarksDemo.
+For more information, check out the example extension, Filtering.


### PR DESCRIPTION
This PR is to update the debugging page with the Mac info (Chromium download and Tableau start-up command, and some formatting changes. Also includes an update to the Events page, to fix sample and instructions. 