### PR TITLE
fixed typos, examples, added descriptions for samples

### DIFF
--- a/_includes/docs_menu.html
+++ b/_includes/docs_menu.html
@@ -36,9 +36,6 @@
         <li>
             <a href="{{ site.baseurl }}/docs/index.html" target="_blank">API Reference</a>
         </li>
-        <li>
-            <a href="https://github.com/tableau/extensions-api#known-issues-as-of-june-14-2017">Known Issues</a>
-        </li>
 		 <li>
             <a href="{{ site.baseurl }}/docs/trex_release-notes.html">Release Notes</a>
         </li>

--- a/docs/trex_api_about.md
+++ b/docs/trex_api_about.md
@@ -31,7 +31,7 @@ The dashboard extension is one type of extension in the Tableau extensions names
       <dashboard-addin/>
     </addin-type>
 ```
-After the extension is intialized, it provides access to the objects in the dashboard, but also has access to the namespaces that are common to all extensions. For example, you can use the `tableau.extensions.environment` to query the environment the dashboard is running in, or `tableau.extensions.settings` to set or get key-value pairs associated with the extension. The `tableau.extensions.settings` can be saved with the workbook, so you can configure the dashboard and the extension in specific ways and then share that configuration with others. 
+After the extension is initialized, it provides access to the objects in the dashboard, but also has access to the namespaces that are common to all extensions. For example, you can use the `tableau.extensions.environment` to query the environment the dashboard is running in, or `tableau.extensions.settings` to set or get key-value pairs associated with the extension. The `tableau.extensions.settings` can be saved with the workbook, so you can configure the dashboard and the extension in specific ways and then share that configuration with others. 
 
 To access the objects in the dashboard, you specify the namespace reserved for dashboard extensions `dashboardContent`, which then gives you access to the dashboard object. For example, the following code snippet gets the array of worksheets in the dashboard.
 
@@ -45,7 +45,7 @@ The following diagram shows an outline of the namespace hierarchy that you trave
 
 ## Using properties and methods in the `dashboard` namespace
 
-The Extensions API is similar to the Tableau JavaScript API. The `dashboard` class or namespace inhierits from an abstract `sheet` class. You can use the [Extensions API Reference]({{site.baseurl}}\docs\index.html) to find the properties and methods that are available for dashboard objects.
+The Extensions API is similar to the Tableau JavaScript API. The `dashboard` class or namespace inherits from an abstract `sheet` class. You can use the [Extensions API Reference]({{site.baseurl}}\docs\index.html) to find the properties and methods that are available for dashboard objects.
 
 For example, after you extract a worksheet object from the dashboard, you can use that worksheet to get properties. such as the name or size, or to call methods that get or apply filters, get data, or set or remove event listeners. 
 

--- a/docs/trex_api_about.md
+++ b/docs/trex_api_about.md
@@ -14,7 +14,7 @@ The Tableau Extensions API is organized by namespaces. The type of extension you
 ## Navigating the top-level `tableau` and `extensions` namespaces
 
 
-The [Extensions API Reference]({{site.baseurl}}\docs\index.html) namespaces are like containers that comprise the classes and methods for communicating with Tableau components. At the highest-level, is the `tableau` namespace, which has no constructs, but contains the `addIn` or extensions namespace. The `tableau` namespace serves primarily as the overall container and keeps the global namespace clean. 
+The [Extensions API Reference]({{site.baseurl}}\docs\index.html) namespaces are like containers that comprise the classes and methods for communicating with Tableau components. At the highest-level, is the `tableau` namespace, which has no constructs, but contains the `extensions` namespace. The `tableau` namespace serves primarily as the overall container and keeps the global namespace clean. 
 
 The `extensions` namespace is the namespace for Tableau extensions. A dashboard extension is one type of extension. When a extension is registered as a dashboard extension, it has access to the `dashboardContent` namespace, and all of the objects and classes of the dashboard. The type of extension you have registered determines what namespaces will be available. Some namespaces, like the `settings`, `environment`, and `ui` are available to all extensions.  
 
@@ -36,7 +36,7 @@ After the extension is intialized, it provides access to the objects in the dash
 To access the objects in the dashboard, you specify the namespace reserved for dashboard extensions `dashboardContent`, which then gives you access to the dashboard object. For example, the following code snippet gets the array of worksheets in the dashboard.
 
 ```python
-   const worksheets = tableau.addIn.dashboardContent.dashboard.worksheets ;
+   const worksheets = tableau.extensions.dashboardContent.dashboard.worksheets ;
 ```
 
 The following diagram shows an outline of the namespace hierarchy that you traverse to get to worksheets.     

--- a/docs/trex_contributing.md
+++ b/docs/trex_contributing.md
@@ -22,12 +22,12 @@ Submitting to the Community Portal {#portal}
 
 4. In the `community_extensions.json` file, add an entry for your extension.  Name, author, and description are required. All other fields are optional.  While we recommend both providing the source code and a hosted version of your extension, you may choose one or the other.  If you choose to provide a hosted version of your extension, see step 5 (skip otherwise).
 
-5. First, host your extension on a web server (see below for suggestions). Second, create a manifest file (`.trex`) where the URL points to the hsted location of your extension.  Finally, in your pull request, place thie manifest file in the `community/CommunityManifests` folder.  Also place the file name into your entry in community_extensions.json.  Ensure the filename matches your manifest file and it is unique from others in the folder.
+5. First, host your extension on a web server (see below for suggestions). Second, create a manifest file (`.trex`) where the URL points to the hosted location of your extension.  Finally, in your pull request, place the manifest file in the `community/CommunityManifests` folder.  Also place the file name into your entry in community_extensions.json.  Ensure the filename matches your manifest file and it is unique from others in the folder.
 
-6. Submit a pull request from the submissions branch of your fork to the submissions branch in the offical repository.
+6. Submit a pull request from the submissions branch of your fork to the submissions branch in the official repository.
 
 
-After that, a member of the Tableau Extensibiltiy team will review your submission.
+After that, a member of the Tableau Extensibility team will review your submission.
 
 Suggestions for hosting your extension {#hosting}
 ---------------------------------------

--- a/docs/trex_create.md
+++ b/docs/trex_create.md
@@ -205,7 +205,7 @@ Use the **Reload** option to refresh and reload the extension in the dashboard.
   
 ## What's next?
 
-- For more information about how you can use Extensions API, go look at the [Samples](https://github.com/tableau/extensions-api/tree/master/Samples/) or follow the [Tutorial](https://github.com/tableau/extensions-api/tree/master/Tutorial/) and learn how to build a dashboard extension, step by step.   
+- For more information about how you can use the Extensions API, go look at the [Samples](https://github.com/tableau/extensions-api/tree/master/Samples/) or follow the [Tutorial](https://github.com/tableau/extensions-api/tree/master/Tutorial/) and learn how to build a dashboard extension, step by step.   
 
 - Get familiar with the programming interface of the Extensions API, see <a href="{{site.baseurl}}/docs/index.html" target="_blank">API Reference</a>.
 

--- a/docs/trex_create.md
+++ b/docs/trex_create.md
@@ -205,7 +205,7 @@ Use the **Reload** option to refresh and reload the extension in the dashboard.
   
 ## What's next?
 
-- For more information about how you can use Extensions API, go look at the [Samples](https://github.com/tableau/extensions-api/tree/master/Samples/) or follow the [Tutorial](https://github.com/tableau/extensions-api/tree/master/Tutorial/HelloFrelard) and learn how to build a dashboard extension, step by step.   
+- For more information about how you can use Extensions API, go look at the [Samples](https://github.com/tableau/extensions-api/tree/master/Samples/) or follow the [Tutorial](https://github.com/tableau/extensions-api/tree/master/Tutorial/) and learn how to build a dashboard extension, step by step.   
 
 - Get familiar with the programming interface of the Extensions API, see <a href="{{site.baseurl}}/docs/index.html" target="_blank">API Reference</a>.
 

--- a/docs/trex_create.md
+++ b/docs/trex_create.md
@@ -174,7 +174,7 @@ $(document).ready(function() {
     tableau.extensions.initializeAsync().then(function() {
 
       // Initialization succeeded! Get the dashboard
-      var dashboard = tableau.addIn.dashboardContent.dashboard; 
+      var dashboard = tableau.extensions.dashboardContent.dashboard; 
 
       // Display the name of dashboard in the UI
       $("#resultBox").html("I'm running in a dashboard named <strong>" + dashboard.name + "</strong>");

--- a/docs/trex_debugging.md
+++ b/docs/trex_debugging.md
@@ -29,14 +29,14 @@ After you've done these steps, debugging will be enabled for all extensions unti
 
 If you are using Tableau Desktop on macOS, you need to open a Terminal window and run a command to enable debugging. 
 
-1. Open a terminal window. 
+1. Open a Terminal window. 
 2. Start Tableau using the following command:
 
    ```
    open /Applications/Tableau\ Desktop\ near.app --args --remote-debugging-port=8696
    ```
 
-**Note:** The remote debuggging port (for example, `8696`) must match the port address you use with Chromium for debugging. This is not the HTTP port that you are using to host your extension. 
+**Note:** The remote debugging port (for example, `8696`) must match the port address you use with Chromium for debugging. This is not the HTTP port that you are using to host your extension, the port that is specified in the manifest file (`.trex`). 
 
 
 ## Download the Chromium Browser
@@ -59,7 +59,7 @@ It can be difficult to hit breakpoints which occur during the loading of your pa
 1. In the **Debug Options** dropdown menu, select **Pause Before Loading**.
 2. Reload your extension (**Debug Options** > **Reload**)
 3. In Chromium, go to the debugging homepage ([http://localhost:8696](http://localhost:8696)). 
-4. To attach to the browser instance, click the frist item listed (it will be completely blank, but it is really there, and the selection is visible when you click on it). 
+4. To attach to the browser instance, click the first item listed (it will be completely blank, but it is really there. The cursor changes so you can select it). 
 4. Click the **Sources** tab in Chromium, under **Event Listener Breakpoints**, click **Script** and enable the **Script First Statement** breakpoint.
 5. Back in Tableau, click the extension zone to load your page.
 6. The debugger will pause each time the first statement of a script runs allowing you to debug the startup process

--- a/docs/trex_events.md
+++ b/docs/trex_events.md
@@ -3,7 +3,7 @@ title: Events and Event Handling
 layout: docs
 ---
 
-In Tableau dashboard extensions, event handling operates at the sheet level. In the Extensions API, the `sheet` is an abstract class that both `dashboard` and `worksheet` inhierit from. You can add event listeners on individual sheets in a dashboard or on the entire dashboard itself. If you have an event listener, when the specified event is raised, the callback method you provide is called to handle the event. You can use event listeners to trigger specific actions based upon dashboard interactions. 
+In Tableau dashboard extensions, event handling operates at the sheet level. In the Extensions API, the `sheet` is an abstract class that both `dashboard` and `worksheet` inherit from. You can add event listeners on individual sheets in a dashboard or on the entire dashboard itself. If you have an event listener, when the specified event is raised, the callback method you provide is called to handle the event. You can use event listeners to trigger specific actions based upon dashboard interactions. 
 
 The Tableau Extension API supports a range of events and provides methods for adding and removing event listeners. To manage the event listener, each sheet has an *event listener manager*. The manager provides a way to add or remove multiple events on sheets independently. 
 

--- a/docs/trex_examples.md
+++ b/docs/trex_examples.md
@@ -85,7 +85,7 @@ To use the dashboard extension samples, you need to start up a web server on you
 
 The samples are set up so that the web server is using port `8765`.  If you need to specify a different port instead of `8765`, you can change ports using Python, if you have Python installed, or you can run another Node.js command.  
 
-From the `extensions-api` folder, start an HTTP server on port \<PORT\>, using one of the following commands:
+From the `extensions-api` folder, start an HTTP server using one of the following commands. Replace `PORT` with the port you are using (for example, `8000`):
 
 * Python 2.x : `python -m SimpleHTTPServer PORT`
 * Python 3.x : `python -m http.server PORT`

--- a/docs/trex_examples.md
+++ b/docs/trex_examples.md
@@ -3,9 +3,53 @@ title: Dashboard Extension Samples
 layout: docs
 ---
 
-To examine the sample source code and to see how Tableau dashboard extensions work, you can clone or download the [Extensions API](https://github.com/tableau/extensions-api) repository on GitHub and run the samples. The samples are in the `Samples` folder. There is also a step-by-step tutorial you can follow in the `Tutorial` folder. 
+The best way to learn how to build your own extensions is to look at the sample code. To examine the sample source files to see how Tableau dashboard extensions work, you can clone or download the [Extensions API](https://github.com/tableau/extensions-api) SDK on GitHub and run the samples. 
+- To download the Extensions API SDK, if you have not already done so, see [Get Started]({{ site.baseurl }}/doc/trex_getstarted.html).
 
-You can also check out the dashboard extensions from the community, see [Community Extensions]({{ site.baseurl }}/community/).
+- You can browse the sample code for the dashboard extensions in the [Samples](https://github.com/tableau/extensions-api/tree/master/Samples?=target="_blank") and the [Tutorial](https://github.com/tableau/extensions-api/tree/master/Tutorial?=target="_blank") folders on GitHub. 
+
+- You can also check out the dashboard extensions from the community, see [Community Extensions]({{ site.baseurl }}/community/).
+
+
+---
+
+
+**In this section**
+
+* TOC
+{:toc}
+
+
+---
+
+The following instructions assume that you have already downloaded and extracted the files or have cloned the Extensions API SDK to your desktop.
+
+
+
+### About the dashboard extension samples
+
+The dashboard extension samples are in the `Samples` folder. There is also a step-by-step tutorial you can follow in the `Tutorial` folder. 
+
+
+
+
+-   **[DataSources](https://github.com/tableau/extensions-api/tree/master/Samples/DataSources?=target="_blank")** 
+     
+    Shows how to use the `getDataSourcesAsync` function to find the names of the data sources for each worksheet in the dashboard. Like the Filtering sample, the DataSources sample makes use the `Promise.all` function to combine the promises from the asynchronous calls together, and then waits for them to resolve. 
+ 
+-   **[Filtering](https://github.com/tableau/extensions-api/tree/master/Samples/Filtering?=target="_blank")** 
+
+     Demonstrates how to use the `getFiltersAsync` function to find and display the active filters in the dashboard and calls the `addEventListener` function to set a `FilterChanged` event on each workbook in the dashboard. Any time a filter value is changed, the extension refreshes the table that displays the active filters. 
+
+-   **[Parameters](https://github.com/tableau/extensions-api/tree/master/Samples/Parameters?=target="_blank")**
+     
+    Finds and displays all the parameters in the dashboard and then sets an event listener that waits for a parameter to change, which triggers a refresh. 
+
+-   **[Settings](https://github.com/tableau/extensions-api/tree/master/Samples/Settings?=target="_blank")**
+ 
+     Uses the `settings` namespace to save settings (key-value pairs) for the extension. Demonstrates how you can save settings for each instance of an extension, which enables sharing common views of a workbook.  
+
+
 
 --- 
 ### Install the manifest files (`.trex`) for the samples 
@@ -24,12 +68,35 @@ Every Tableau extension has a manifest file (`.trex`) that describes the extensi
 
 To use the dashboard extension samples, you need to start up a web server on your computer to host the HTML pages. If you downloaded or cloned the Extensions API repository, you can start the web service in the root directory of the repository on your computer. 
 
-- From the root of this directory, start an HTTP server on port 8765.
-	- Python 2.x : `python -m SimpleHTTPServer 8765`
-	- Python 3.x : `python -m http.server 8765`
-	- Node.js : `npm install http-server -g && http-server -p 8765`
+1. Go to to the the `extensions-api` folder.
+2. To install the web server components, run the following command:
+   ```
+   npm install
+   ```
+3. To start the web server, run the following command:
+   ```
+   npm start
+   ```
 
 
 
 
+### Instructions for starting a web server on a different port
+
+The samples are set up so that the web server is using port `8765`.  If you need to specify a different port instead of `8765`, you can change ports using Python, if you have Python installed, or you can run another Node.js command.  
+
+From the `extensions-api` folder, start an HTTP server on port \<PORT\>, using one of the following commands:
+
+* Python 2.x : `python -m SimpleHTTPServer PORT`
+* Python 3.x : `python -m http.server PORT`
+* Node.js : `npm install http-server -g && http-server -p PORT`
+
+The port you use for the web server also has to match the port specified in the manifest file (`.trex`) for the server.
+
+```
+<source-location>
+      <url>http://localhost:PORT/samples/parameters/parameters.html</url>
+</source-location>
+
+```
 

--- a/docs/trex_getstarted.md
+++ b/docs/trex_getstarted.md
@@ -40,12 +40,12 @@ If you want to create an extension or work with the sample code, make sure you h
 
 You can get the Tableau Extensions API SDK in two ways. Clone the repository if you want to contribute to the open source project or keep current with the latest changes. Download the `.zip` file if you want to view the samples and work on your own.
 
-- Open a terminal in the directory where you want to download the Tableau Extensions SDK.  Then run the following command to clone
+- Open a terminal in the directory where you want to copy the Tableau Extensions SDK.  Then run the following command to clone
    the Tableau Extensions API git repository:
 
    `git clone https://github.com/tableau/extensions-api.git`
 
-- Download the [Tableau Extensions API SDK (.zip file)](https://github.com/tableau/extensions-api/archive/master.zip).
+- Download the [Tableau Extensions API SDK (.zip file)](https://github.com/tableau/extensions-api/archive/master.zip) and extract the files to your computer.
 
 
 
@@ -64,13 +64,17 @@ The version of Tableau that supports the Extension API is only available from fr
 ---
 ### Start a web server to host the sample dashboard extensions
 
-To use the dashboard extension samples, you need to start up a web server on your computer to host the HTML pages. If you downloaded or cloned the Extensions API repository, you can start the web service in the root directory of the repository on your computer. 
+To use the dashboard extension samples, you need to start up a web server on your computer to host the HTML pages. If you downloaded or cloned the Extensions API repository, you can start the web service in the root directory of the repository on your computer. For example, if you downloaded the `extensions-api-master.zip` file to your `Downloads` directory, after you extract the files, the path might be `Downloads\extensions-api-master\extensions-api\`.
 
-- From the root of this directory, start an HTTP server on port 8765.
-	- Python 2.x : `python -m SimpleHTTPServer 8765`
-	- Python 3.x : `python -m http.server 8765`
-	- Node.js : `npm install http-server -g && http-server -p 8765`
-
+1. Navigate to the the `extensions-api` directory.
+2. To install the web server components, run the following command:
+   ```
+   npm install
+   ```
+3. To start the web server, run the following command:
+   ```
+   npm start
+   ```
 
 
 
@@ -111,12 +115,10 @@ You can add multiple instances of an extension to a dashboard or to multiple das
   
 ## What's next?
 
-- For more information about how you can use Extensions API, go look at the [Samples](https://github.com/tableau/extensions-api/tree/master/Samples/) or follow the [Tutorial](https://github.com/tableau/extensions-api/tree/master/Tutorial) and learn how to build a dashboard extension, step by step.   
+- For more information about how you can use Extensions API, go look at the [Samples (GitHub)](https://github.com/tableau/extensions-api/tree/master/Samples/), or follow the [Tutorial (GitHub)](https://github.com/tableau/extensions-api/tree/master/Tutorial) and learn how to build a dashboard extension, step by step. If you downloaded or cloned the repository, look in the `Samples` and `Tutorial` folder on your computer.  
 
 - For general information about creating Tableau extensions, see [Creating a Tableau Extension]({{site.baseurl}}/docs/trex_create.html).
 - To get familiar with the programming interface for the Extensions API, see the <a href="{{site.baseurl}}/docs/index.html" target="_blank">API Reference</a>.
-
-For more information about how you can use dashboard extensions, see the [ReactJs](https://github.com/tableau/ProjectFrelard/tree/master/Examples/ReactJs) examples or the [HelloFrelard](https://github.com/tableau/ProjectFrelard/tree/master/Examples/HelloFrelard) example.   
 
 
 For information about debugging your extension, see [Remote Debugging of JavaScript and HTML]({{site.baseurl}}/docs/trex_debugging.html).

--- a/docs/trex_getstarted.md
+++ b/docs/trex_getstarted.md
@@ -54,7 +54,7 @@ You can get the Tableau Extensions API SDK in two ways. Clone the repository if 
 ### Download and install Tableau Desktop
 
 
-The version of Tableau that supports the Extension API is only available from from the **Extensions API Developer Preview** on [https://prerelease.tableau.com](https://prerelease.tableau.com). 
+The version of Tableau that supports the Extension API is only available from the **Extensions API Developer Preview** on [https://prerelease.tableau.com](https://prerelease.tableau.com). 
 1. Download and install Tableau Desktop from the [Extensions API Developer Preview](https://prerelease.tableau.com) site). 
    Under **Resources**, click **Extensions API Software Downloads**. There are separate installation applications for Windows and macOS. You can also download the Extensions API JavaScript library, which is needed if you are going to develop your own extensions.
 

--- a/index.html
+++ b/index.html
@@ -1,11 +1,11 @@
 ---
-title: Project Frelard Home
+title: Extensions API Home
 layout: home
 indexed_by_search: false
 ---
 <header class="jumbotron hero-spacer text-center">
     <h1>Tableau Extensions API</h1>
-    <p>Create extensions for Tableau. The extensions are web apps that can have two-way communications with Tableau.</p>
+    <p>Create extensions for Tableau. The extensions are web apps that can have two-way communication with Tableau.</p>
     <p>This site will get you up and running with Tableau extensions. The Tableau Extensions API samples and documentation are all open source.</p>
     <br />
     <a class="btn btn-primary btn-lg" href="{{ site.baseurl }}/docs/trex_getstarted.html" role="button">Get Started</a>&nbsp;&nbsp;


### PR DESCRIPTION
Removed a couple of code snippets in the docs that still had "tableau.addIn" 
Removed the Known Issues link that was broken (Known issues moved to the CC site). 