### PR TITLE
Removed the meta tag that blocked search engines

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,6 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="robots" content="noindex">
 
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">


### PR DESCRIPTION
Removed the noindex tag that blocks search engines from showing the Extensions API docs in search results.