### PR TITLE
Adding Security topic to table of contents

### DIFF
--- a/_includes/docs_menu.html
+++ b/_includes/docs_menu.html
@@ -31,7 +31,10 @@
         <li>
             <a href="{{ site.baseurl }}/docs/trex_logging.html">Use Log Files to Troubleshoot Dashboard Extensions</a>
         </li>
-		<li>
+	 <li>
+            <a href="{{ site.baseurl }}/docs/trex_security.html">Security and Tableau Extensions</a>		
+	</li>
+	<li>
             <a href="{{ site.baseurl }}/docs/trex_contributing.html">Hosting and Contributing to the Community Portal</a>
         </li>
 


### PR DESCRIPTION
I missed adding this change in the original doc update. Had it locally, but forgot to add it to the PR.