### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ The Extensions API lets you do more without leaving Tableau. Build Tableau exten
 4. Run `npm start`.
 5. Launch Tableau and use the sample in a dashboard.
 
+ >**Note** The web server just serves the extension samples and tutorial, which have URLs similar to the following: `http://localhost:8765/Samples/DataSources/datasources.html`
+ >   This local web server is not intended to serve the Extensions API Help pages. 
+ >   View the Help on GitHub at [https://tableau.github.io/extensions-api](https://tableau.github.io/extensions-api).
+
 ## Submissions
 We would love submissions to either the Docs or Sample code! To contribute, first sign our CLA that can be found [here](https://tableau.github.io/contributing.html).  To submit a contribution, please fork the repository then submit a pull request to the `submissions` branch.
 


### PR DESCRIPTION
Adding a note about the location of the Extensions API Help pages. 
We use GitHub pages (https://tableau.github.io/extensions-api).  
We don't provide a way to host local Help pages.