### PR TITLE
Fix manifest example

### DIFF
--- a/docs/trex_manifest.md
+++ b/docs/trex_manifest.md
@@ -31,7 +31,7 @@ If a workbook is saved with an extension and then later opened on another comput
 
 ```xml
         <?xml version="1.0" encoding="utf-8"?> 
-        <manifest manifest-version="0.1" xmlns="http://wwww.tableau.com/xml/extension_manifest">
+        <manifest manifest-version="0.1" xmlns="http://www.tableau.com/xml/extension_manifest">
           <dashboard-extension id="com.example.extensions.name" extension-version="0.1.0">
             <default-locale>en_US</default-locale>
             <name resource-id="name"/>
@@ -41,7 +41,7 @@ If a workbook is saved with an extension and then later opened on another comput
             <source-location>
               <url>SCHEME://SERVER[:PORT][/PATH]</url> 
             </source-location>
-            <icon>Base64-Encoded ICON</icon>
+            <icon></icon>
             <permissions>
     	       <permission>full data</permission>
             </permissions>

--- a/docs/trex_manifest.md
+++ b/docs/trex_manifest.md
@@ -36,7 +36,7 @@ If a workbook is saved with an extension and then later opened on another comput
             <default-locale>en_US</default-locale>
             <name resource-id="name"/>
             <description>Extension Description</description>
-            <author name="USERNAME" email="USER@example.com" organization="My Company" website="www.example.com"/>
+            <author name="USERNAME" email="USER@example.com" organization="My Company" website="https://www.example.com"/>
             <min-api-version>1.1</min-api-version>
             <source-location>
               <url>SCHEME://SERVER[:PORT][/PATH]</url> 


### PR DESCRIPTION
`wwww` -> `www`

Removed the Base 64 icon since it doesn't seem to be used at the moment