### PR TITLE
Update ux_controls_ui_patterns.md - fixing broken table

### DIFF
--- a/docs/Interaction_Guidelines/ux_controls_ui_patterns.md
+++ b/docs/Interaction_Guidelines/ux_controls_ui_patterns.md
@@ -59,7 +59,7 @@ A button communicates what happens when a user touches it. Button labels can con
 ![buttons](imgs/3-buttons-cover.png)
 
 ### Usage
-|  | How to use |
+| Button | How to use |
 | --- | --- |
 | **Call-to-Action  &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;**  | These buttons are primarily used in dialogues to indicate an action. Use colors to communicate function–for example, green is commonly used for confirmation buttons. Learn more about color usage at **[Colors](Style Guidelines/6 - Color.md)**.<br><br>You may also want to utilize branding practices on buttons. Learn more at **[Branding your Extension](Style Guidelines/4 - Branding your Extension.md)**. |
 | **Greyscale** | Greyscale buttons are used either to indicate a secondary action, or a button that has been disabled and a particular action needs to be taken before proceeding. |


### PR DESCRIPTION
Adding a heading to a column in a table. The Markdown looked fine, but Jekyll didn't recognize it as a table without a heading to the column.