### PR TITLE
updating release notes for the version 1.2 library

### DIFF
--- a/docs/Interaction_Guidelines/ux_controls_ui_patterns.md
+++ b/docs/Interaction_Guidelines/ux_controls_ui_patterns.md
@@ -59,8 +59,9 @@ A button communicates what happens when a user touches it. Button labels can con
 ![buttons](imgs/3-buttons-cover.png)
 
 ### Usage
+
 | Button | How to use |
-| --- | --- |
+|----|:-----|
 | **Call-to-Action  &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;**  | These buttons are primarily used in dialogues to indicate an action. Use colors to communicate function–for example, green is commonly used for confirmation buttons. Learn more about color usage at **[Colors](Style Guidelines/6 - Color.md)**.<br><br>You may also want to utilize branding practices on buttons. Learn more at **[Branding your Extension](Style Guidelines/4 - Branding your Extension.md)**. |
 | **Greyscale** | Greyscale buttons are used either to indicate a secondary action, or a button that has been disabled and a particular action needs to be taken before proceeding. |
 | **Text Button &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;** | This is a low-attention button, and should only be used to provide a secondary option in the case that the user wants to perform an action that isn’t the primary action. |

--- a/docs/trex_release-notes.md
+++ b/docs/trex_release-notes.md
@@ -12,6 +12,29 @@ layout: docs
 See also: [Known Issues]({{site.baseurl}}/docs/trex_known_issues.html)
 
 ----
+### Extensions API library v1.2
+*April 2019*
+
+* Tableau Extensions API library: `tableau-extensions-1.2.0.js` <br>(download or clone the Extensions API repository on [GitHub](https://github.com/tableau/extensions-api){:target="_blank"}) <br/>
+
+
+
+
+About this release: 
+
+* The Extensions API library version 1.2 (`tableau-extensions-1.2.0.js`) is backward compatible with previous releases of the library. You can use the Extensions API library version 1.2 for extensions on Tableau 2018.2 and later. The library contains logic to handle any necessary conversions for the supported version of Tableau the extension is running in. For the best experience, you should always use the latest version of the library with the extensions you create. 
+
+
+Bugs fixed in this release: 
+
+* Fixed in the Extensions API library 1.2, the type of `DataValue.value` is now the raw native value as a JavaScript type, rather than always defaulting to **String**. A `DataValue.value` can be one of the following JavaScript types: **String**, **Number**, **Boolean**, or **Date**.
+ A `DataValue` is returned as a property of a `DataTable` in methods, such as `getSummaryDataAsync()` or `getUnderlyingDataAsync()`.  Note that special values, regardless of type, are always returned as **String** values surrounded by percent signs, such as `%null%`, or `%no-access%`. <br/>**Important!** If your code depended on the type of `DataValue.value` always being a **String**, that code will now break with this fix.
+
+* The `environment.apiVersion` property now correctly reports the version of the Extensions API library that the extension is using.
+
+* The documentation for the <a href="{{site.baseurl}}/docs/interfaces/worksheet.html#selectmarksbyvalueasync" target="_blank"><code>selectMarksByValueAsync</code></a> method has been corrected. If you are calling the method, be sure to specify the complete namespace for the `SelectionUpdateType` enum that is passed to the method as the `updateType` parameter.  For example, use `tableau.SelectionUpdateType.Replace`, to replace the currently selected marks with the values you specify in the method call. 
+
+----
 
 ### Tableau 2019.1
 *February 2019*


### PR DESCRIPTION

@nikhillakshman @johnDance  @Kovner 

These are the release notes that have been updated with John's corrections. I also added another item to mention the doc fix for the `SelecttionUpdateType` enum. 

* The documentation for the <a href="https://tableau.github.io/extensions-api/docs/interfaces/worksheet.html#selectmarksbyvalueasync" target="_blank"><code>selectMarksByValueAsync</code></a> method has been corrected. If you are calling the method, be sure to specify the complete namespace for the `SelectionUpdateType` enum that is passed to the method as the `updateType` parameter.  For example, use `tableau.SelectionUpdateType.Replace`, to replace the currently selected marks with the values you specify in the method call. 

And I fixed (I hope!) some broken formatting in the UX Design Guide. A table isn't getting rendered as a table. 
