### PR TITLE
updated the library file name with new convention

### DIFF
--- a/docs/trex_create.md
+++ b/docs/trex_create.md
@@ -6,7 +6,7 @@ layout: docs
 To create a Tableau extension you need the following components.
 
 - A manifest file that identifies and describes the extension.
-- The Tableau Extensions API JavaScript library (`tableau-extensions-N.N.N.js`)
+- The Tableau Extensions API JavaScript library (`tableau.extensions.N.N.N.js`)
 - A web page that uses the library. The web page provides controls that interact with Tableau objects and data in the dashboard.
 - Additional JavaScript and HTML and CSS files as needed for your web app.
 - A web server to host your web app.
@@ -112,7 +112,7 @@ Your web application must include an HTML page. This page should link to the Ext
 
         <!-- Tableau Extensions API Library  -->
         <!-- library is in the /lib directory -->
-        <script src="../../lib/tableau-extensions-1.latest.js"></script>
+        <script src="../../lib/tableau.extensions.1.latest.js"></script>
 
         <!-- Your JavaScript code that uses the Extensions API goes here -->
         <script src="./hello-extension.js"></script>
@@ -129,15 +129,15 @@ Your web application must include an HTML page. This page should link to the Ext
     </html>
     ```
 
-   The sample code includes a link to the JavaScript library (`tableau-extensions-1.latest.js`), which is available in the `/lib` folder. The sample code also includes links to jQuery and Bootstrap libraries. 
+   The sample code includes a link to the JavaScript library (`tableau.extensions.1.latest.js`), which is available in the `/lib` folder. The sample code also includes links to jQuery and Bootstrap libraries. 
 
 
-3. If necessary, adjust the relative path to the Extensions API JavaScript library (`tableau-extensions-1.latest.js`), which is available in the `/lib` folder. 
+3. If necessary, adjust the relative path to the Extensions API JavaScript library (`tableau.extensions.1.latest.js`), which is available in the `/lib` folder. 
 
    ```html
 
    <!-- Tableau Extensions API Library  -->
-   <script src="../../lib/tableau-extensions-1.latest.js"></script>
+   <script src="../../lib/tableau.extensions.1.latest.js"></script>
 
    ```
 

--- a/docs/trex_error_handling.md
+++ b/docs/trex_error_handling.md
@@ -43,49 +43,4 @@ tableau.extensions.ui.displayDialogAsync(args... ).then((args... ) => {
 
 ```
 
-## Handle Extensions API errors when the dashboard is not visible
 
- In Tableau Server or Tableau Online version 2018.3 and later, when the browser window is not visible (that is, when the browser window Tableau is running in is minimized or in the background), the Extensions API method calls are blocked and an error object is returned. If you have code that might run when the dashboard is not visible, you should add code to check if the window is visible so that you can handle the error. If you are using `tableau-extensions-1.1.0.js` or later, the error code returned in this case is `VISIBILITY_ERROR`.
-
-### What happens when the error occurs
-
- This error can occur if an Extensions API method is called while Tableau is not in the foreground. For example, this could happen if the user switches tabs or minimizes the browser window and there is a timer that triggers the API call. When the user subsequently returns to the dashboard view, an error dialog box will appear.
-
-   ![]({{site.baseurl}}/assets/ext_visibility_error_dialog.png)
-
-
-### Identifying the error as a visibility-error
-
- To find out the cause, you can use the debugging tools in the browser. If you check the Console window, in Chrome for example, you might see an error message similar to the following.
-
-   ![]({{site.baseurl}}/assets/ext_visibility_err_console.png)
-
-
-### Add a check for visibility and add an event listener
-
-The Extensions API methods are intended to be used in scenarios where some manual interaction is required. However, there might be cases where a method is called on an interval, or there is a delay in execution, and the browser window that contains the extension is no longer visible when the method call is made. In these cases, you could use the [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) and an event handler to avoid having your users encounter the `visibility-error`.
-
-
-The following example shows how this error could be handled using an event listener for `visibilitychange`. You can create your own `visibilityhandlermethod` method if you need to wrap your Extensions API calls when the browser window is visible.
-
-
-```javascript
-
-
-    document.addEventListener('visibilitychange', visibilityhandlermethod, false);
-
-
-    // 
-    function visibilityhandlermethod() {
-     if (document.hidden) {
-         // do something while you pause the extension execution
-      }    else  {
-            // do stuff
-        // call the Extensions API
-      }
-    }
-
-
-
-
-```

--- a/docs/trex_getstarted.md
+++ b/docs/trex_getstarted.md
@@ -111,7 +111,7 @@ Looking at the files that make up an extension will give you an idea of how an e
 
     ```html
     <!-- Extensions Library  -->
-    <script src="../../lib/tableau-extensions-1.latest.js"></script>
+    <script src="../../lib/tableau.extensions.1.latest.js"></script>
 
     <!-- Our extension's code -->
     <script src="./datasources.js"></script>

--- a/docs/trex_known_issues.md
+++ b/docs/trex_known_issues.md
@@ -32,11 +32,18 @@ When an extension needs full data access and the user does not have full data pe
 
 ### Tableau Extensions API library version 1.0.0 
 
-If you are debugging your extension, you might see this message in the Debugging Tools console window if you are using the released version of the 1.0.0 library (for example, `tableau-extensions-1.0.0.js`) with a version of Tableau that is newer than Tableau 2018.2.
+If you are debugging your extension, you might see this message in the Debugging Tools console window if you are using the 1.0.0 version of the Extensions API library (for example, `tableau-extensions-1.0.0.js`) with a version of Tableau that is newer than Tableau 2018.2.
 
 ```
 This is an alpha version of the Extensions API. Please upgrade to an official release.
 
 ```
 
-You can safely ignore this warning. However, if you are using the 1.0.0 library, be sure to upgrade to the latest version, or use or `tableau-extensions-1.latest.js`, so that you always pick up the most recent update of that version of the library when it becomes available.
+You can safely ignore this warning. However, if you are using the 1.0.0 library, be sure to upgrade to the latest version.
+
+To avoid having to update your code to reference a new version of the 1.x library every time you download a new version, you can specify `tableau.extensions.1.latest.js`. That way, when you replace the previous version of the library with the most recent update, your extension should just work.
+
+```
+ <script src="../../lib/tableau.extensions.1.latest.js"></script>
+
+```

--- a/docs/trex_overview.md
+++ b/docs/trex_overview.md
@@ -28,7 +28,7 @@ Plenty! Using the Extensions API, you can create dashboard extensions that enabl
 
 ## Extensions API library
 
-The Extensions API is a JavaScript library that you link to from your web application. The Extensions API library (`tableau-extensions-n.n.n.js`) gives your application access to Tableau dashboard content, including worksheets, filters, marks, and parameters. In your JavaScript code, you can set up event listeners to get notified when events occur on the dashboard. You can use the Extensions API to apply filters, or to get data back from selected marks in a worksheet. 
+The Extensions API is a JavaScript library that you link to from your web application. The Extensions API library (`tableau.extensions.n.n.n.js`) gives your application access to Tableau dashboard content, including worksheets, filters, marks, and parameters. In your JavaScript code, you can set up event listeners to get notified when events occur on the dashboard. You can use the Extensions API to apply filters, or to get data back from selected marks in a worksheet. 
 
 For more information about how you can use Extensions API, go look at the [Samples](https://github.com/tableau/extensions-api/tree/master/Samples/). 
 

--- a/docs/trex_release-notes.md
+++ b/docs/trex_release-notes.md
@@ -15,14 +15,23 @@ See also: [Known Issues]({{site.baseurl}}/docs/trex_known_issues.html)
 ### Extensions API library v1.2
 *April 2019*
 
-* Tableau Extensions API library: `tableau-extensions-1.2.0.js` <br>(download or clone the Extensions API repository on [GitHub](https://github.com/tableau/extensions-api){:target="_blank"}) <br/>
+* Tableau Extensions API library: `tableau.extensions.1.2.0.js` <br>(download or clone the Extensions API repository on [GitHub](https://github.com/tableau/extensions-api){:target="_blank"}) <br/>
 
 
 
 
 About this release: 
 
-* The Extensions API library version 1.2 (`tableau-extensions-1.2.0.js`) is backward compatible with previous releases of the library. You can use the Extensions API library version 1.2 for extensions on Tableau 2018.2 and later. The library contains logic to handle any necessary conversions for the supported version of Tableau the extension is running in. For the best experience, you should always use the latest version of the library with the extensions you create. 
+* The Extensions API library version 1.2 (`tableau.extensions.1.2.0.js`) is backward compatible with previous releases of the library. You can use the Extensions API library version 1.2 for extensions on Tableau 2018.2 and later. The library contains logic to handle any necessary conversions for the supported version of Tableau the extension is running in. For the best experience, you should always use the latest version of the library with the extensions you create. 
+
+* The names of the Extension API library files have changed. The hypens (-) have been removed from the file name (was `tableau-extensions-*`, now `tableau.extensions.*`). Starting with the 1.2 library, the names of the library files are as follows: 
+```
+tableau.extensions.1.2.0.js
+tableau.extensions.1.2.0.min.js
+tableau.extensions.1.latest.js
+tableau.extensions.1.latest.min.js
+```
+**Note** If you have previously been referencing `tableau-extensions-1.latest.js` in your code, you will need to use the new naming convention when you upgrade to the 1.2 library (`tableau.extensions.1.latest.js`). 
 
 
 Bugs fixed in this release: 
@@ -49,7 +58,7 @@ Changes in this release:
 
 * Show and hide capabilities for extensions (now you see it, now you don't). For more information, see [Show and Hide Objects in the Dashboard]({{site.baseurl}}/docs/trex_show_hide.html).
 
-* Starting in Tableau Server and Tableau Online 2019.1, when the dashboard is not visible (minimized or in the background), Extensions API method calls are blocked. If you have code that might run when the browser window is not visible, you should add code to check the state of the window Tableau is running in and then handle that condition appropriately. If you don't check the state, and your extension makes an API call, a `"visibility-error"` could be thrown because of the blocked state. Be sure to use the latest version of the library (`tableau-extensions-1.1.0.js`). For more information, see [Handle Extensions API errors when the dashboard is not visible]({{site.baseurl}}/docs/trex_error_handling.html#handle-extensions-api-errors-when-the-dashboard-is-not-visible).
+
 
 
 

--- a/docs/trex_security.md
+++ b/docs/trex_security.md
@@ -127,7 +127,7 @@ Or use site-relative or protocol-agnostic links (that is, where the protocol is 
 ```html
 
     <!-- Extensions Library ) -->
-    <script src="../../lib/tableau-extensions-0.8.0.js"></script>
+    <script src="../../lib/tableau.extensions.1.2.0.js"></script>
 
     <!-- The extensions's code -->
     <script src="./example.js"></script>

--- a/docs/trex_xss_guidance.md
+++ b/docs/trex_xss_guidance.md
@@ -3,7 +3,7 @@ title: Cross-Site Scripting and Extension Security
 layout: docs
 ---
 
-As a developer of dashboard extensions, there are certain precautions you should take and best practices you can follow to helo ensure that your extensions are secure. A dashboard extension is a web application that runs inside the Tableau dashboard, and as a web application, your dashboard extension could be vulnerable to cross-site scripting (XSS). Cross-site scripting is an attack where a malicious user injects client-side code (typically, JavaScript) to execute in your web application. When other users load the web pages of your extension, the attacker's scripts can run, potentially stealing information or redirecting the browser to another web page.
+As a developer of dashboard extensions, there are certain precautions you should take and best practices you can follow to help ensure that your extensions are secure. A dashboard extension is a web application that runs inside the Tableau dashboard, and as a web application, your dashboard extension could be vulnerable to cross-site scripting (XSS). Cross-site scripting is an attack where a malicious user injects client-side code (typically, JavaScript) to execute in your web application. When other users load the web pages of your extension, the attacker's scripts can run, potentially stealing information or redirecting the browser to another web page.
 
 
 **In this section**


### PR DESCRIPTION
- changed references to lib files to use new convention
- removed page visibility section from error handling topic and from release notes (added in 2019.1)
- fixed library reference on known issues page to make it clear that  they have to download the lib. 