### PR TITLE
Update trex_security.md

### DIFF
--- a/docs/trex_security.md
+++ b/docs/trex_security.md
@@ -127,7 +127,7 @@ Or use site-relative or protocol-agnostic links (that is, where the protocol is 
 ```html
 
     <!-- Extensions Library ) -->
-    <script src="../../lib/tableau.extensions.1.2.0.js"></script>
+    <script src="../../lib/tableau.extensions.1.latest.js"></script>
 
     <!-- The extensions's code -->
     <script src="./example.js"></script>


### PR DESCRIPTION
changing the reference to `1.latest`  instead of the current 1.2 release. 