### PR TITLE
Scope down our types usage to just the two libs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,6 @@
     "sourceMap": true,                     /* Generates corresponding '.map' file. */
     "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
     "baseUrl": "./Samples-Typescript",
-    "typeRoots": ["./node_modules/@tableau", "./node_modules/@types"]
+    "types": ["@tableau/extensions-api-types", "jquery"]
   }
 }


### PR DESCRIPTION
fixes npm build error.

Issue is caused by the fact that tabextsandbox does not export types from the module / package. Additional issue is that we were using the @tableau typeroot which was automatically including it in the typescript build. I've limited the scope to only include the types which we use.
Additionally, I'm going to figure out how to configure the tabextsandbox package to not cause tscompiler build issues for others that accidentally include it in their type references.

cc @brtal @ashwinar 