### PR TITLE
Update to use version 1.6 of extensions-api-types

### DIFF
--- a/Samples-Typescript/Parameters/parameters.ts
+++ b/Samples-Typescript/Parameters/parameters.ts
@@ -1,10 +1,9 @@
 import {
+    DataType,
     Parameter,
     ParameterChangedEvent,
     ParameterDomainRestriction
 } from '@tableau/extensions-api-types';
-
-import { DataType } from '@tableau/extensions-api-types/ExternalContract/Namespaces/Tableau';
 
 // Wrap everything in an anonymous function to avoid polluting the global namespace
 (async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "extensions-api-sdk",
-  "version": "0.1.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -33,9 +33,9 @@
       }
     },
     "@tableau/extensions-api-types": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@tableau/extensions-api-types/-/extensions-api-types-1.5.2.tgz",
-      "integrity": "sha512-kaXLDBQFqOre+DOPADsxYFIy6YjUZUxedGRUzLQaJ5iMLpu+44r5bCGJRvw5qxZtz8gfEb7NQ3i/uHs1YdXs/A==",
+      "version": "1.6.0-pre.16",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@tableau/extensions-api-types/-/@tableau/extensions-api-types-1.6.0-pre.16.tgz",
+      "integrity": "sha1-+/+VOkMcU9XG4s2O/TaxUPx+XhE=",
       "dev": true,
       "requires": {
         "@types/lodash": "^4.14.126"
@@ -62,9 +62,15 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.170",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.170.tgz",
-      "integrity": "sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==",
+      "version": "4.14.172",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@types/lodash/-/lodash-4.14.172.tgz",
+      "integrity": "sha1-qtd0wo57/Xpn3iVAjgPuWow9Aoo=",
+      "dev": true
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha1-0zV0eaD9/dWQf+Z+F+CoXJBuEwE=",
       "dev": true
     },
     "@types/sizzle": {
@@ -74,191 +80,190 @@
       "dev": true
     },
     "@webassemblyjs/ast": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
-      "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+      "integrity": "sha1-vYUGBLQEJFmlpBzX0zjL7Wle2WQ=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/helper-module-context": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/wast-parser": "1.8.5"
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0"
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
-      "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
+      "integrity": "sha1-PD07Jxvd/ITesA9xNEQ4MR1S/7Q=",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
-      "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
+      "integrity": "sha1-ID9nbjM7lsnaLuqzzO8zxFkotqI=",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
-      "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
+      "integrity": "sha1-oUQtJpxf6yP8vJ73WdrDVH8p3gA=",
       "dev": true
     },
     "@webassemblyjs/helper-code-frame": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
-      "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
+      "integrity": "sha1-ZH+Iks0gQ6gqwMjF51w28dkVnyc=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/wast-printer": "1.8.5"
+        "@webassemblyjs/wast-printer": "1.9.0"
       }
     },
     "@webassemblyjs/helper-fsm": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
-      "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
+      "integrity": "sha1-wFJWtxJEIUZx9LCOwQitY7cO3bg=",
       "dev": true
     },
     "@webassemblyjs/helper-module-context": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
-      "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
+      "integrity": "sha1-JdiIS3aDmHGgimxvgGw5ee9xLwc=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "mamacro": "^0.0.3"
+        "@webassemblyjs/ast": "1.9.0"
       }
     },
     "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
-      "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+      "integrity": "sha1-T+2L6sm4wU+MWLcNEk1UndH+V5A=",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
-      "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
+      "integrity": "sha1-WkE41aYpK6GLBMWuSXF+QWeWU0Y=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-buffer": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/wasm-gen": "1.8.5"
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0"
       }
     },
     "@webassemblyjs/ieee754": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
-      "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
+      "integrity": "sha1-Fceg+6roP7JhQ7us9tbfFwKtOeQ=",
       "dev": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
-      "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
+      "integrity": "sha1-8Zygt2ptxVYjoJz/p2noOPoeHJU=",
       "dev": true,
       "requires": {
         "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/utf8": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
-      "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
+      "integrity": "sha1-BNM7Y2945qaBMifoJAL3Y3tiKas=",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
-      "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
+      "integrity": "sha1-P+bXnT8PkiGDqoYALELdJWz+6c8=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-buffer": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/helper-wasm-section": "1.8.5",
-        "@webassemblyjs/wasm-gen": "1.8.5",
-        "@webassemblyjs/wasm-opt": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5",
-        "@webassemblyjs/wast-printer": "1.8.5"
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/helper-wasm-section": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0",
+        "@webassemblyjs/wasm-opt": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "@webassemblyjs/wast-printer": "1.9.0"
       }
     },
     "@webassemblyjs/wasm-gen": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
-      "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
+      "integrity": "sha1-ULxw7Gje2OJ2OwGhQYv0NJGnpJw=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/ieee754": "1.8.5",
-        "@webassemblyjs/leb128": "1.8.5",
-        "@webassemblyjs/utf8": "1.8.5"
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/ieee754": "1.9.0",
+        "@webassemblyjs/leb128": "1.9.0",
+        "@webassemblyjs/utf8": "1.9.0"
       }
     },
     "@webassemblyjs/wasm-opt": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
-      "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
+      "integrity": "sha1-IhEYHlsxMmRDzIES658LkChyGmE=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-buffer": "1.8.5",
-        "@webassemblyjs/wasm-gen": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5"
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0"
       }
     },
     "@webassemblyjs/wasm-parser": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
-      "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
+      "integrity": "sha1-nUjkSCbfSmWYKUqmyHRp1kL/9l4=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-api-error": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/ieee754": "1.8.5",
-        "@webassemblyjs/leb128": "1.8.5",
-        "@webassemblyjs/utf8": "1.8.5"
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-api-error": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/ieee754": "1.9.0",
+        "@webassemblyjs/leb128": "1.9.0",
+        "@webassemblyjs/utf8": "1.9.0"
       }
     },
     "@webassemblyjs/wast-parser": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
-      "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
+      "integrity": "sha1-MDERXXmsW9JhVWzsw/qQo+9FGRQ=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/floating-point-hex-parser": "1.8.5",
-        "@webassemblyjs/helper-api-error": "1.8.5",
-        "@webassemblyjs/helper-code-frame": "1.8.5",
-        "@webassemblyjs/helper-fsm": "1.8.5",
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/floating-point-hex-parser": "1.9.0",
+        "@webassemblyjs/helper-api-error": "1.9.0",
+        "@webassemblyjs/helper-code-frame": "1.9.0",
+        "@webassemblyjs/helper-fsm": "1.9.0",
         "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/wast-printer": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
-      "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
+      "version": "1.9.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
+      "integrity": "sha1-STXVTIX+9jewDOn1I3dFHQDUeJk=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/wast-parser": "1.8.5",
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
       }
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
       "dev": true
     },
     "@xtuc/long": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0=",
       "dev": true
     },
     "accepts": {
@@ -306,8 +311,8 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "integrity": "sha1-81mGrOuRr63sQQL72FAUlQzvpk0=",
       "dev": true
     },
     "ajv-keywords": {
@@ -338,9 +343,9 @@
       }
     },
     "anymatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "version": "3.1.2",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -350,8 +355,8 @@
     },
     "aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
       "dev": true
     },
     "argparse": {
@@ -404,20 +409,29 @@
       }
     },
     "asn1.js": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "version": "5.4.1",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha1-EamAuE67kXgc41sP3C7ilON4Pwc=",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
+          "dev": true
+        }
       }
     },
     "assert": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
-      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
@@ -457,8 +471,8 @@
     },
     "async-each": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8=",
       "dev": true,
       "optional": true
     },
@@ -583,9 +597,9 @@
       }
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "version": "1.5.1",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=",
       "dev": true
     },
     "basic-auth": {
@@ -601,31 +615,21 @@
     },
     "binary-extensions": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0=",
       "dev": true,
       "optional": true
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "bluebird": {
       "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
       "dev": true
     },
     "bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "version": "5.2.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha1-NYhgZ0OWxpl3canQUfzBtX1K4AI=",
       "dev": true
     },
     "body-parser": {
@@ -716,8 +720,8 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
       "dev": true,
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -730,8 +734,8 @@
     },
     "browserify-cipher": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
       "dev": true,
       "requires": {
         "browserify-aes": "^1.0.4",
@@ -741,8 +745,8 @@
     },
     "browserify-des": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -752,43 +756,70 @@
       }
     },
     "browserify-rsa": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "version": "4.1.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha1-sv0Gtbda4pf3zi3GUfkY9b4VjI0=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
+        "bn.js": "^5.0.0",
         "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
-      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "version": "4.2.1",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/browserify-sign/-/browserify-sign-4.2.1.tgz",
+      "integrity": "sha1-6vSt1G3VS+O7OzbAzxWrvrp5VsM=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.3",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+          "dev": true
+        }
       }
     },
     "browserify-zlib": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
       }
     },
     "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "version": "4.9.2",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -828,8 +859,8 @@
     },
     "cacache": {
       "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
-      "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/cacache/-/cacache-12.0.4.tgz",
+      "integrity": "sha1-ZovL0QWutfHZL+JVcOyVJcj6pAw=",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.5",
@@ -910,26 +941,26 @@
       }
     },
     "chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.2",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha1-26OXb8rbAW9m/TZQIdkWANAcHnU=",
       "dev": true,
       "optional": true,
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       },
       "dependencies": {
         "braces": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -938,8 +969,8 @@
         },
         "fill-range": {
           "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -948,15 +979,15 @@
         },
         "is-number": {
           "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
           "dev": true,
           "optional": true
         },
         "to-regex-range": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -967,23 +998,20 @@
     },
     "chownr": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs=",
       "dev": true
     },
     "chrome-trace-event": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
-      "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.0"
-      }
+      "version": "1.0.3",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+      "integrity": "sha1-EBXs7UdB4V0GZkqVfbv1DQQeJqw=",
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -1035,14 +1063,54 @@
       "dev": true
     },
     "cliui": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "version": "7.0.4",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.2",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "co": {
@@ -1124,30 +1192,80 @@
       }
     },
     "concurrently": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-4.1.2.tgz",
-      "integrity": "sha512-Kim9SFrNr2jd8/0yNYqDTFALzUX1tvimmwFWxmp/D4mRI+kbqIIwE2RkBDrxS2ic25O1UgQMI5AtBqdtX3ynYg==",
+      "version": "6.2.1",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/concurrently/-/concurrently-6.2.1.tgz",
+      "integrity": "sha1-2ID8HXdVkIRzL6UUCSo9UQmg1b8=",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2",
-        "date-fns": "^1.30.1",
-        "lodash": "^4.17.15",
-        "read-pkg": "^4.0.1",
-        "rxjs": "^6.5.2",
+        "chalk": "^4.1.0",
+        "date-fns": "^2.16.1",
+        "lodash": "^4.17.21",
+        "read-pkg": "^5.2.0",
+        "rxjs": "^6.6.3",
         "spawn-command": "^0.0.2-1",
-        "supports-color": "^4.5.0",
-        "tree-kill": "^1.2.1",
-        "yargs": "^12.0.5"
+        "supports-color": "^8.1.0",
+        "tree-kill": "^1.2.2",
+        "yargs": "^16.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        }
       }
     },
     "console-browserify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true,
-      "requires": {
-        "date-now": "^0.1.4"
-      }
+      "version": "1.2.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha1-ZwY871fOts9Jk6KrOlWECujEkzY=",
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -1190,8 +1308,8 @@
     },
     "copy-concurrently": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
       "dev": true,
       "requires": {
         "aproba": "^1.1.1",
@@ -1220,19 +1338,27 @@
       "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c="
     },
     "create-ecdh": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+      "version": "4.0.4",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha1-1uf0v/pmc2CFoHYv06YyaE2rzE4=",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "elliptic": "^6.5.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
+          "dev": true
+        }
       }
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -1244,8 +1370,8 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
@@ -1271,8 +1397,8 @@
     },
     "crypto-browserify": {
       "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
       "dev": true,
       "requires": {
         "browserify-cipher": "^1.0.0",
@@ -1305,15 +1431,9 @@
       }
     },
     "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-      "dev": true
-    },
-    "date-now": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "version": "2.23.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/date-fns/-/date-fns-2.23.0.tgz",
+      "integrity": "sha1-TohslBZZrwz3sw+v3R6qN+iHiKk=",
       "dev": true
     },
     "debug": {
@@ -1419,9 +1539,9 @@
       "dev": true
     },
     "des.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
-      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "version": "1.0.1",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha1-U4IULhvcU/hdhtU+X0qn3rkeCEM=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -1448,13 +1568,21 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
         "randombytes": "^2.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
+          "dev": true
+        }
       }
     },
     "doctrine": {
@@ -1468,14 +1596,14 @@
     },
     "domain-browser": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
       "dev": true
     },
     "duplexify": {
       "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.0.0",
@@ -1509,8 +1637,8 @@
     },
     "elliptic": {
       "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha1-2jfOvTHnmhNn6UG1ku0fvr1Yq7s=",
       "dev": true,
       "requires": {
         "bn.js": "^4.11.9",
@@ -1523,15 +1651,15 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+          "version": "4.12.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
           "dev": true
         },
         "inherits": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
           "dev": true
         }
       }
@@ -1703,6 +1831,12 @@
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -2006,8 +2140,8 @@
     },
     "eslint-scope": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -2082,15 +2216,15 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
+      "version": "3.3.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/events/-/events-3.3.0.tgz",
+      "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=",
       "dev": true
     },
     "evp_bytestokey": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
       "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
@@ -2325,15 +2459,15 @@
       }
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "version": "3.1.3",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "version": "2.1.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -2344,8 +2478,8 @@
     },
     "figgy-pudding": {
       "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
-      "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+      "integrity": "sha1-tO7oFIq7Adzx0aw0Nn1Z4S+mHW4=",
       "dev": true
     },
     "figures": {
@@ -2367,13 +2501,6 @@
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -2432,8 +2559,8 @@
     },
     "find-cache-dir": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
@@ -2443,8 +2570,8 @@
       "dependencies": {
         "pkg-dir": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
           "dev": true,
           "requires": {
             "find-up": "^3.0.0"
@@ -2493,8 +2620,8 @@
     },
     "flush-write-stream": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
-      "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha1-jdfYc6G6vCB9lOrQwuDkQnbr8ug=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -2563,8 +2690,8 @@
     },
     "fsevents": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
       "dev": true,
       "optional": true
     },
@@ -2593,9 +2720,9 @@
       }
     },
     "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "version": "2.0.5",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true
     },
     "get-stdin": {
@@ -2634,9 +2761,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -2761,19 +2888,45 @@
       }
     },
     "hash-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "version": "3.1.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha1-VcOB2eBuHSmXqIO0o/3f5/DTrzM=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+          "dev": true
+        }
       }
     },
     "hash.js": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -2807,8 +2960,8 @@
     },
     "hosted-git-info": {
       "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha1-3/wL+aIcAiCQkPKqaUKeFBTa8/k=",
       "dev": true
     },
     "http-errors": {
@@ -2867,9 +3020,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "version": "1.2.1",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I=",
       "dev": true
     },
     "iferr": {
@@ -2913,8 +3066,8 @@
     },
     "infer-owner": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha1-xM78qo5RBRwqQLos6KPScpWvlGc=",
       "dev": true
     },
     "inflight": {
@@ -3068,8 +3221,8 @@
     },
     "is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -3296,10 +3449,16 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0=",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true
     },
     "json-stable-stringify": {
@@ -3363,6 +3522,12 @@
         "type-check": "~0.3.2"
       }
     },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -3377,8 +3542,8 @@
     },
     "loader-runner": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
-      "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/loader-runner/-/loader-runner-2.4.0.tgz",
+      "integrity": "sha1-7UcGa/5TTX6ExMe5mYwqdWB9k1c=",
       "dev": true
     },
     "loader-utils": {
@@ -3415,8 +3580,8 @@
     },
     "lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
       "requires": {
         "yallist": "^3.0.2"
@@ -3424,8 +3589,8 @@
     },
     "make-dir": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
       "dev": true,
       "requires": {
         "pify": "^4.0.1",
@@ -3434,17 +3599,11 @@
       "dependencies": {
         "pify": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
           "dev": true
         }
       }
-    },
-    "mamacro": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
-      "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
-      "dev": true
     },
     "map-age-cleaner": {
       "version": "0.1.3",
@@ -3472,8 +3631,8 @@
     },
     "md5.js": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -3543,12 +3702,20 @@
     },
     "miller-rabin": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
+          "dev": true
+        }
       }
     },
     "mime": {
@@ -3579,8 +3746,8 @@
     },
     "minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
       "dev": true
     },
     "minimalistic-crypto-utils": {
@@ -3605,8 +3772,8 @@
     },
     "mississippi": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/mississippi/-/mississippi-3.0.0.tgz",
+      "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
       "dev": true,
       "requires": {
         "concat-stream": "^1.5.0",
@@ -3675,13 +3842,6 @@
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
-    "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
-    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -3714,9 +3874,9 @@
       "dev": true
     },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "version": "2.6.2",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
       "dev": true
     },
     "next-tick": {
@@ -3733,8 +3893,8 @@
     },
     "node-libs-browser": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
-      "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+      "integrity": "sha1-tk9RPRgzhiX5A0bSew0jXmMfZCU=",
       "dev": true,
       "requires": {
         "assert": "^1.1.1",
@@ -3772,8 +3932,8 @@
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -3784,8 +3944,8 @@
     },
     "normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
       "dev": true,
       "optional": true
     },
@@ -4018,15 +4178,15 @@
       "dev": true
     },
     "pako": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+      "version": "1.0.11",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
       "dev": true
     },
     "parallel-transform": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
-      "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/parallel-transform/-/parallel-transform-1.2.0.tgz",
+      "integrity": "sha1-kEnKN9bLIYLDsdLHIL6U0UpYFPw=",
       "dev": true,
       "requires": {
         "cyclist": "^1.0.1",
@@ -4035,14 +4195,13 @@
       }
     },
     "parse-asn1": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
-      "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
+      "version": "5.1.6",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/parse-asn1/-/parse-asn1-5.1.6.tgz",
+      "integrity": "sha1-OFCAo+wTy2KmLTlAnLPoiETNrtQ=",
       "dev": true,
       "requires": {
-        "asn1.js": "^4.0.0",
+        "asn1.js": "^5.2.0",
         "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
@@ -4078,8 +4237,8 @@
     },
     "path-browserify": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha1-5sTd1+06onxoogzE5Q4aTug7vEo=",
       "dev": true
     },
     "path-dirname": {
@@ -4114,9 +4273,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
       "dev": true
     },
     "path-to-regexp": {
@@ -4126,9 +4285,9 @@
       "dev": true
     },
     "pbkdf2": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "version": "3.1.2",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha1-3YIqoIh1gOUvGgOdw+2hCO+uMHU=",
       "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
@@ -4139,9 +4298,9 @@
       }
     },
     "picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "version": "2.3.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI=",
       "dev": true,
       "optional": true
     },
@@ -4386,8 +4545,8 @@
     },
     "public-encrypt": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -4396,6 +4555,14 @@
         "parse-asn1": "^5.0.0",
         "randombytes": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
+          "dev": true
+        }
       }
     },
     "pump": {
@@ -4410,8 +4577,8 @@
     },
     "pumpify": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
       "dev": true,
       "requires": {
         "duplexify": "^3.6.0",
@@ -4421,8 +4588,8 @@
       "dependencies": {
         "pump": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -4433,8 +4600,8 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
       "dev": true
     },
     "qs": {
@@ -4456,8 +4623,8 @@
     },
     "randombytes": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
@@ -4465,8 +4632,8 @@
     },
     "randomfill": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
       "dev": true,
       "requires": {
         "randombytes": "^2.0.5",
@@ -4492,14 +4659,29 @@
       }
     },
     "read-pkg": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
-      "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
+      "version": "5.2.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha1-e/KVQ4yloz5WzTDgU7NO5yUMk8w=",
       "dev": true,
       "requires": {
-        "normalize-package-data": "^2.3.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0"
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        }
       }
     },
     "readable-stream": {
@@ -4518,9 +4700,9 @@
       }
     },
     "readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4591,12 +4773,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
-    },
-    "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
     "require-uncached": {
@@ -4702,8 +4878,8 @@
     },
     "ripemd160": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -4741,9 +4917,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "version": "6.6.7",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha1-kKwBisq/SRv2UEQjXVhjxNq4BMk=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -4772,8 +4948,8 @@
     },
     "schema-utils": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/schema-utils/-/schema-utils-1.0.0.tgz",
+      "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
       "dev": true,
       "requires": {
         "ajv": "^6.1.0",
@@ -4782,21 +4958,21 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "version": "6.12.6",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^2.0.1",
+            "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
           }
         },
         "ajv-keywords": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-          "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+          "version": "3.5.2",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+          "integrity": "sha1-MfKdpatuANHC0yms97WSlhTVAU0=",
           "dev": true
         }
       }
@@ -4878,8 +5054,8 @@
     },
     "serialize-javascript": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha1-tSXhI4SJpez8Qq+sw/6Z5mb0sao=",
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
@@ -4940,8 +5116,8 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -5110,8 +5286,8 @@
     },
     "source-list-map": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-      "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/source-list-map/-/source-list-map-2.0.1.tgz",
+      "integrity": "sha1-OZO9hzv8SEecyp6jpUeDXHwVSzQ=",
       "dev": true
     },
     "source-map": {
@@ -5135,8 +5311,8 @@
     },
     "source-map-support": {
       "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -5145,8 +5321,8 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -5164,9 +5340,9 @@
       "dev": true
     },
     "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "version": "3.1.1",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha1-3s6BrJweZxPl99G28X1Gj6U9iak=",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -5174,15 +5350,15 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "version": "2.3.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha1-PyjOGnegA3JoPq3kpDMYNSeiFj0=",
       "dev": true
     },
     "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha1-z3D1BILu/cmOPOCmgz5KU87rpnk=",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -5190,9 +5366,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "version": "3.0.10",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
+      "integrity": "sha1-DZvszN5wA9bGWNSH3UijLwvzAUs=",
       "dev": true
     },
     "split-string": {
@@ -5212,8 +5388,8 @@
     },
     "ssri": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
-      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha1-FXk5E08gRk5zAd26PpD/qPdyisU=",
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1"
@@ -5260,8 +5436,8 @@
     },
     "stream-browserify": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
-      "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=",
       "dev": true,
       "requires": {
         "inherits": "~2.0.1",
@@ -5270,8 +5446,8 @@
     },
     "stream-each": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
-      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/stream-each/-/stream-each-1.2.3.tgz",
+      "integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -5280,8 +5456,8 @@
     },
     "stream-http": {
       "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/stream-http/-/stream-http-2.8.3.tgz",
+      "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
       "dev": true,
       "requires": {
         "builtin-status-codes": "^3.0.0",
@@ -5293,8 +5469,8 @@
     },
     "stream-shift": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha1-1wiCgVWasneEJCebCHfaPDktWj0=",
       "dev": true
     },
     "string-width": {
@@ -5364,18 +5540,18 @@
       "dev": true
     },
     "supports-color": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+      "version": "8.1.1",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
       "dev": true,
       "requires": {
-        "has-flag": "^2.0.0"
+        "has-flag": "^4.0.0"
       },
       "dependencies": {
         "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "version": "4.0.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         }
       }
@@ -5444,8 +5620,8 @@
     },
     "terser": {
       "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/terser/-/terser-4.8.0.tgz",
+      "integrity": "sha1-YwVjQ9fHC7KfOvZlhlpG/gOg3xc=",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -5455,16 +5631,16 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
     },
     "terser-webpack-plugin": {
       "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
-      "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+      "integrity": "sha1-oheu+uozDnNP+sthIOwfoxLWBAs=",
       "dev": true,
       "requires": {
         "cacache": "^12.0.2",
@@ -5480,8 +5656,8 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -5500,8 +5676,8 @@
     },
     "through2": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
@@ -5509,9 +5685,9 @@
       }
     },
     "timers-browserify": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
-      "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+      "version": "2.0.12",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/timers-browserify/-/timers-browserify-2.0.12.tgz",
+      "integrity": "sha1-RKRcEfv0B/NPl7zNFXfGUjYbAO4=",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -5573,8 +5749,8 @@
     },
     "tree-kill": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha1-TKCakJLIi3OnzcXooBtQeweQoMw=",
       "dev": true
     },
     "ts-loader": {
@@ -5647,6 +5823,12 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha1-jSojcNPfiG61yQraHFv2GIrPg4s=",
+      "dev": true
+    },
     "type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -5664,9 +5846,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
-      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
+      "version": "3.9.10",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha1-cPORCselHta+952ngAaQsZv3eLg=",
       "dev": true
     },
     "union": {
@@ -5697,8 +5879,8 @@
     },
     "unique-filename": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
       "dev": true,
       "requires": {
         "unique-slug": "^2.0.0"
@@ -5706,8 +5888,8 @@
     },
     "unique-slug": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha1-uqvOkQg/xk6UWw861hPiZPfNTmw=",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
@@ -5761,15 +5943,15 @@
     },
     "upath": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha1-j2bbzVWog6za5ECK+LA1pQRMGJQ=",
       "dev": true,
       "optional": true
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.1",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -5821,8 +6003,8 @@
     },
     "util": {
       "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
-      "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/util/-/util-0.11.1.tgz",
+      "integrity": "sha1-MjZzNyDsZLsn9uJvQhqqLhtYjWE=",
       "dev": true,
       "requires": {
         "inherits": "2.0.3"
@@ -5848,8 +6030,8 @@
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
@@ -5863,15 +6045,15 @@
       "dev": true
     },
     "vm-browserify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
-      "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+      "version": "1.1.2",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha1-eGQcSIuObKkadfUR56OzKobl3aA=",
       "dev": true
     },
     "watchpack": {
       "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
-      "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/watchpack/-/watchpack-1.7.5.tgz",
+      "integrity": "sha1-EmfmxV4Lm1vkTCAjrtVDeiwmxFM=",
       "dev": true,
       "requires": {
         "chokidar": "^3.4.1",
@@ -5882,8 +6064,8 @@
     },
     "watchpack-chokidar2": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
-      "integrity": "sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
+      "integrity": "sha1-OFAAcu5uzmbzdpk2lQ6hdxvhyVc=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -5892,8 +6074,8 @@
       "dependencies": {
         "anymatch": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5915,15 +6097,15 @@
         },
         "binary-extensions": {
           "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
           "dev": true,
           "optional": true
         },
         "chokidar": {
           "version": "2.1.8",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5943,14 +6125,10 @@
         },
         "fsevents": {
           "version": "1.2.13",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -5987,8 +6165,8 @@
         },
         "readdirp": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6000,59 +6178,82 @@
       }
     },
     "webpack": {
-      "version": "4.39.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.39.3.tgz",
-      "integrity": "sha512-BXSI9M211JyCVc3JxHWDpze85CvjC842EvpRsVTc/d15YJGlox7GIDd38kJgWrb3ZluyvIjgenbLDMBQPDcxYQ==",
+      "version": "4.46.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/webpack/-/webpack-4.46.0.tgz",
+      "integrity": "sha1-v5tEBOogoHNgXgoBHRiNd8tq1UI=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-module-context": "1.8.5",
-        "@webassemblyjs/wasm-edit": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5",
-        "acorn": "^6.2.1",
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/wasm-edit": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "acorn": "^6.4.1",
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.1.0",
+        "enhanced-resolve": "^4.5.0",
         "eslint-scope": "^4.0.3",
         "json-parse-better-errors": "^1.0.2",
         "loader-runner": "^2.4.0",
         "loader-utils": "^1.2.3",
         "memory-fs": "^0.4.1",
         "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^0.5.3",
         "neo-async": "^2.6.1",
         "node-libs-browser": "^2.2.1",
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.1",
-        "watchpack": "^1.6.0",
+        "terser-webpack-plugin": "^1.4.3",
+        "watchpack": "^1.7.4",
         "webpack-sources": "^1.4.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+          "version": "6.4.2",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/acorn/-/acorn-6.4.2.tgz",
+          "integrity": "sha1-NYZv1xBSjpLeEM8GAWSY5H454eY=",
           "dev": true
         },
         "ajv": {
-          "version": "6.10.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "version": "6.12.6",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^2.0.1",
+            "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
           }
         },
         "ajv-keywords": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-          "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+          "version": "3.5.2",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+          "integrity": "sha1-MfKdpatuANHC0yms97WSlhTVAU0=",
           "dev": true
+        },
+        "enhanced-resolve": {
+          "version": "4.5.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+          "integrity": "sha1-Lzz9hNvjtIfxjy2y7x4GSlccpew=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.5.0",
+            "tapable": "^1.0.0"
+          },
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.5.0",
+              "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/memory-fs/-/memory-fs-0.5.0.tgz",
+              "integrity": "sha1-MkwBKIuIZSlm0WHbd4OHIIRajjw=",
+              "dev": true,
+              "requires": {
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
+              }
+            }
+          }
         }
       }
     },
@@ -6177,8 +6378,8 @@
     },
     "webpack-sources": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-      "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/webpack-sources/-/webpack-sources-1.4.3.tgz",
+      "integrity": "sha1-7t2OwLko+/HL/plOItLYkPMwqTM=",
       "dev": true,
       "requires": {
         "source-list-map": "^2.0.0",
@@ -6187,8 +6388,8 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -6216,56 +6417,84 @@
     },
     "worker-farm": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
-      "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/worker-farm/-/worker-farm-1.7.0.tgz",
+      "integrity": "sha1-JqlMU5G7ypJhUgAvabhKS/dy5ag=",
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
       }
     },
     "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "version": "7.0.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "version": "5.0.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
           "dev": true
         },
         "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
+          "version": "3.0.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+          "dev": true
         },
         "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "version": "4.2.2",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "version": "6.0.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -6299,39 +6528,76 @@
     },
     "yallist": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
       "dev": true
     },
     "yargs": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+      "version": "16.2.0",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
       "dev": true,
       "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^3.0.0",
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^11.1.1"
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.2",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
+          "dev": true
+        }
       }
     },
     "yargs-parser": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
+      "version": "20.2.9",
+      "resolved": "https://artifactory.prod.tableautools.com/artifactory/api/npm/tab-npm/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha1-LrfcOwKJcY/ClfNidThFxBoMlO4=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extensions-api-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Sample code and documentation for the Tableau Extensions API.",
   "scripts": {
     "build": "npm run lint && webpack --config webpack.config.js --display-error-details",
@@ -21,15 +21,15 @@
     "http-server": "^0.12.3"
   },
   "devDependencies": {
-    "@tableau/extensions-api-types": "1.5.2",
+    "@tableau/extensions-api-types": "1.6.0-pre.16",
     "@tableau/tabextsandbox": "^1.1.0",
     "@types/jquery": "^3.3.29",
-    "concurrently": "^4.1.0",
+    "concurrently": "^6.2.1",
     "semistandard": "^11.0.0",
     "ts-loader": "^5.4.5",
     "tslint": "^5.16.0",
     "typescript": "^3.9.10",
-    "webpack": "^4.30.0",
+    "webpack": "^4.44.1",
     "webpack-cli": "^3.3.1"
   },
   "semistandard": {

--- a/tslint.json
+++ b/tslint.json
@@ -20,7 +20,9 @@
                 ]
             }
         ],
-        "only-arrow-functions": false
+        "only-arrow-functions": false,
+        // extension-api-types submodules are subject to change. import only from "@tableau/extensions-api-types".
+        "import-blacklist": [true, ["@tableau/extensions-api-types/.*"]]
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
1. Update to usage of 1.6 types
2. npm audit fix
3. prohibit accessing private packages of @tableau/extesions-api-types