### PR TITLE
Fixed typo in datasources.html

### DIFF
--- a/Samples/DataSources/datasources.html
+++ b/Samples/DataSources/datasources.html
@@ -18,7 +18,7 @@
     <script src="../../lib/tableau.extensions.1.latest.js"></script>
 
     <!-- Our extension's code -->
-    <script src="./dataSources.js"></script>
+    <script src="./datasources.js"></script>
   </head>
   <body>
     <div class="container">


### PR DESCRIPTION
The file is called `datasources.js` and not `dataSources.js`, so the example was not working properly