### PR TITLE
Update references and links to downloadable .zip file

### DIFF
--- a/docs/trex_contributing.md
+++ b/docs/trex_contributing.md
@@ -22,7 +22,7 @@ Submitting to the Community Portal {#portal}
 
 1. First, host your extension on a web server (see below for suggestions). Second, create a manifest file (`.trex`) where the URL points to the hosted location of your extension.  Finally, in your pull request, place the manifest file in the `community/CommunityManifests` folder.  Also place the file name into your entry in community_extensions.json.  Ensure the filename matches your manifest file and it is unique from others in the folder.
 
-1. Submit a pull request from your fork to the master branch in the official repository.
+1. Submit a pull request from your fork to the main branch in the official repository.
 
 
 After that, a member of the Tableau Extensibility team will review your submission.

--- a/docs/trex_getstarted.md
+++ b/docs/trex_getstarted.md
@@ -58,14 +58,14 @@ You can get the Tableau Extensions API SDK in two ways. Clone the repository if 
 
    `git clone https://github.com/tableau/extensions-api.git`
 
-* Download the [Tableau Extensions API SDK (.zip file)](https://github.com/tableau/extensions-api/archive/master.zip) and extract the files to your computer.
+* Download the [Tableau Extensions API SDK (.zip file)](https://github.com/tableau/extensions-api/archive/main.zip) and extract the files to your computer.
 
 
 
 ---
 ### Start a web server to host the sample dashboard extensions
 
-To use the dashboard extension samples, you need to start up a web server on your computer to host the HTML pages. If you downloaded or cloned the Extensions API repository, you can start the web service in the root directory of the repository on your computer. For example, if you downloaded the `extensions-api-master.zip` file to your `Downloads` directory, after you extract the files, the path might be `Downloads\extensions-api-master\extensions-api\`. 
+To use the dashboard extension samples, you need to start up a web server on your computer to host the HTML pages. If you downloaded or cloned the Extensions API repository, you can start the web service in the root directory of the repository on your computer. For example, if you downloaded the `extensions-api-main.zip` file to your `Downloads` directory, after you extract the files, the path might be `Downloads\extensions-api-main\extensions-api\`. 
 
 1. Navigate to the `extensions-api` directory.
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ indexed_by_search: false
     <p>This site will get you up and running with Tableau extensions. The Tableau Extensions API samples and documentation are all open source.</p>
     <br />
     <a class="btn btn-primary btn-lg" href="{{ site.baseurl }}/docs/trex_getstarted.html" role="button">Get Started</a>&nbsp;&nbsp;
-    <a class="btn btn-primary btn-lg" href="https://github.com/tableau/extensions-api/archive/master.zip" role="button">Download</a>
+    <a class="btn btn-primary btn-lg" href="https://github.com/tableau/extensions-api/archive/main.zip" role="button">Download</a>
 </header>
 <div class="row">
 


### PR DESCRIPTION
@johnDance @seanmakesgames @Kovner 
Changing the name of the branch to `main` also changed the name of the downloadable `.zip` file. 
Updated links and references to the file and branch name. 