### PR TITLE
update docs with Tableau Exchange branding

### DIFF
--- a/_includes/guide_menu.html
+++ b/_includes/guide_menu.html
@@ -30,7 +30,7 @@
         <li class="nav-header">Deploying your Extension</li>
         <li>
         <li>
-            <a href="{{ site.baseurl }}/docs/ux_extension_gallery.html">Submitting your Extension to the Extension Gallery</a>
+            <a href="{{ site.baseurl }}/docs/ux_extension_gallery.html">Submitting your Extension to the Tableau Exchange</a>
         </li>
 
     </ul>

--- a/docs/trex_publish.md
+++ b/docs/trex_publish.md
@@ -32,12 +32,12 @@ However, to run on Tableau Server or Tableau Online, your extension must:
 |**Note** If you want to test your extension with Tableau Online and you are running an extension on `http://localhost` during development, see [Load and view localhost content on sites that use secure connections]({{site.baseurl}}/docs/trex_security.html#load-and-view-localhost-content-on-sites-that-use-secure-connections)|
 
 
- Tableau Server and Tableau Online have settings that control whether dashboard extensions are allowed to run and whether specific extensions can access the the underlying data in a dashboard.
+ Tableau Server and Tableau Online have settings that control whether dashboard extensions are allowed to run and whether specific extensions can access the underlying data in a dashboard.
 
 
  To enable a dashboard extension on Tableau Server or Tableau Online, the server administrator or the site administrator (Tableau Online) must allow extensions for the site. The administrators can then choose to enable the default policy that allows *unknown* extensions that only request summary data to run, provided users grant the extension permission. These extensions are unknown in the sense that they have not been explicitly added to the safe list or to the blocked list on Tableau Server or Tableau Online.  
 
- If your extension requires access to full data (underlying data) the server or site administrator must add the URL of your extension to a safe list and must explicitly grant the extension access to full data. The server or site administrator can also configure whether users of your extension will see prompts requesting permission to run. 
+ If your extension requires access to full data (underlying data) the server or site administrator must add the URL of your extension to a safe list and must explicitly grant the extension access to full data. The server or site administrator can also configure whether users of your extension will see prompts requesting permission to run.
 
 The following flowchart shows how the settings on Tableau Server or Tableau Online determine whether an extension is allowed or denied permission to run.
 
@@ -50,11 +50,11 @@ The following flowchart shows how the settings on Tableau Server or Tableau Onli
 
 
 
-## Publishing a dashboard extension to the Extension Gallery
+## Publishing a dashboard extension to the Tableau Exchange
 
-If you want to make your dashboard extension readily available to a large number of people, you can take steps to have your extension added to the [Tableau Extension Gallery](https://extensiongallery.tableau.com/).
+If you want to make your dashboard extension readily available to a large number of people, you can take steps to have your extension added to the [Tableau Exchange](https://exchange.tableau.com/).
 
-Publishing your extension to the gallery means that people will be able to discover your extension, find out what it can do, and then add the extension to their dashboards, all while working within Tableau.
+Publishing your extension to the Tableau Exchange means that people will be able to discover your extension, find out what it can do, and then add the extension to their dashboards, all while working within Tableau.
 
 In addition to the requirements for all extensions to ensure security and usability, such as:
  * Using HTTPS
@@ -62,12 +62,12 @@ In addition to the requirements for all extensions to ensure security and usabil
  * Declaring data access requirements
  * Providing a URL that customers can use to get support for your the extension
  
- Dashboard extensions that appear in the gallery must also:
+ Dashboard extensions that appear in the Tableau Exchange must also:
 
 * Follow the Design Guidelines for Dashboard Extensions (user interaction and style guidelines for user interface elements).
-* Ensure that the information in the extension manifest file (`.trex`) matches the content that you will publish in the Extension Gallery. For example, the `name`, `description` fields are used to populate the name and description fields in the Extension Gallery.  The icon you use in the manifest should also be the icon that is used in the gallery. You need to provide a 280x280 pixel `.png` version of the icon. 
+* Ensure that the information in the extension manifest file (`.trex`) matches the content that you will publish in the Tableau Exchange. For example, the `name`, `description` fields are used to populate the name and description fields in the Tableau Exchange.  The icon you use in the manifest should also be the icon that is used in the Exchange. You need to provide a 280x280 pixel `.png` version of the icon. 
 
-For information about getting your extension into the Extension Gallery, see [Submitting your Extension to the Extension Gallery]({{site.baseurl}}/docs/ux_extension_gallery.html){:target="_blank"}.
+For information about getting your extension into the Tableau Exchange, see [Submitting your Extension to the Tableau Exchange]({{site.baseurl}}/docs/ux_extension_gallery.html){:target="_blank"}.
 
 For information about designing an extension, see [Design Guidelines for Dashboard Extensions]({{site.baseurl}}/docs/ux_design.html){:target="_blank"}.
 

--- a/docs/ux_extension_gallery.md
+++ b/docs/ux_extension_gallery.md
@@ -1,18 +1,18 @@
 ---
-title: Submitting your Extension to the Extension Gallery
+title: Submitting your Extension to the Tableau Exchange
 layout: guide
 ---
 
 
-You may be interested in sharing your extension for others to download and use in their dashboards. To submit to our [Extension Gallery](https://extensiongallery.tableau.com/) online, make sure you have the following components gathered. 
+You may be interested in sharing your extension for others to download and use in their dashboards. To submit to our [Tableau Exchange](https://exchange.tableau.com/) online, make sure you have the following components gathered.
 
-**[Gallery Card](#gallery-card-example)**
+**[Exchange Card](#gallery-card-example)**
 
 * Extension Name
 * Extension Icon
 * Tagline
 
-**[Gallery Page](#gallery-page-example)**
+**[Exchange Page](#gallery-page-example)**
 
 * Description
 * Developer Info
@@ -24,10 +24,10 @@ You may be interested in sharing your extension for others to download and use i
 
 ---
 
-## Gallery Card Example
-This is what an extension looks like to a user while browsing the Extension Gallery. 
+## Tableau Exchange Card Example
+This is what an extension looks like to a user while browsing the Tableau Exchange.
 
-![gallery card example](imgs/gallery_card_example.png)
+![exchange card example](imgs/gallery_card_example.png)
 
 |     | Details | 
 | --- | ------- | 
@@ -38,10 +38,10 @@ This is what an extension looks like to a user while browsing the Extension Gall
 
 &nbsp; 
 
-## Gallery Page Example
+## Exchange Page Example
 Users reach pages like this when they want to know more about a particular extension. 
 
-![gallery page example](imgs/gallery_page_example.png)
+![exchange page example](imgs/gallery_page_example.png)
 
 |     | Details | 
 | --- | ------- | 
@@ -53,4 +53,4 @@ Users reach pages like this when they want to know more about a particular exten
 
 ## How to Submit your Extension
 
-After completing your extension, fill out the [Extension Gallery Submission form](https://tabsoft.co/gallerysubmit){:target="_blank"}{:ref="noopener"} with your information and extension details. The extension name in the template needs to match the name you specified for your extension in the manifest file (`.trex`). The 280x280 pixel `.png` icon that you attach with your submission must look like the icon you included in your manifest file (they just have different dimensions). Our developers from the Developer Platform team at Tableau will let you know the next steps including legal agreements after you submit. If you have any questions about the gallery please send them to [extensiongallery@tableau.com](extensiongallery@tableau.com){:target="_blank"}{:ref="noopener"}.
+After completing your extension, fill out the [Tableau Exchange Submission form](https://tabsoft.co/gallerysubmit){:target="_blank"}{:ref="noopener"} with your information and extension details. The extension name in the template needs to match the name you specified for your extension in the manifest file (`.trex`). The 280x280 pixel `.png` icon that you attach with your submission must look like the icon you included in your manifest file (they just have different dimensions). Our developers from the Developer Platform team at Tableau will let you know the next steps including legal agreements after you submit. If you have any questions about the Tableau Exchange please send them to [extensiongallery@tableau.com](extensiongallery@tableau.com){:target="_blank"}{:ref="noopener"}.


### PR DESCRIPTION
@Craigfis @seanmakesgames @bcantoni 

Changed "Extensions Gallery" to "Tableau Exchange" in the following files:

* trex_publish.md
* ux_extension_gallery.md   // note - I didn't change the file name. I don't think it's too critical at the moment. 
* ux_menu.html  // this is the TOC for the Design Guide

I also updated the links to point to Tableau Exchange.
Note that the Design Guide has some links and information about submitting the extension that still point to the original gallery submission site and still refers to the support email (mailto:extensiongallery@tableau.com)