### PR TITLE
TFSID:1362792 VizAPI custom title field; Tableau Exchange changes, misc edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Extensions API lets you do more without leaving Tableau. Build Tableau exten
 ## Setup and Running Samples
 
 ### Prerequisites
-* You must have Node.js and npm installed. You can get these from [http://nodejs.org](http://nodejs.org).
+* You must have Node.js and npm installed. You can get these from [https://nodejs.org](https://nodejs.org).
 
 ### Install Extensions API SDK Components and Start Server
 
@@ -35,14 +35,13 @@ The Extensions API lets you do more without leaving Tableau. Build Tableau exten
 
 ### Typescript Development
 Samples written in Typescript are located in the `Samples-Typescript` folder.
-If you want to use TypeScript to write your extensions, you can run a script that starts up the HTTP server and actively listens for changes to the `.ts` files located in the `Sample-Typescript` folder. You can then add your extension to the folder and use the script to transpile your extension to JavaScript.
+If you want to use TypeScript to write your extensions, you can run a script that starts up the HTTP server and actively listens for changes to the `.ts` files located in the `Samples-Typescript` folder. You can then add your extension to the folder and use the script to transpile your extension to JavaScript.
 
 * To start the the HTTP server and listen for changes to the `.ts` files.
 
     **npm run dev**
 
 For more information, see [Use TypeScript with the Extensions API](https://tableau.github.io/extensions-api/docs/trex_typescript.html).
-
 
 ### Sandboxed Extension Development Environment
 
@@ -56,22 +55,17 @@ Tableau is introducing development support for Sandboxed Extensions with Tableau
 
 For more information, see [Create and Test Sandboxed Extensions](https://tableau.github.io/extensions-api/docs/trex_sandbox_test.html).
 
+## Contributions
+Contributions and improvements by the community are welcomed!
+See the LICENSE file for current open-source licensing and use information.
 
-## Submissions
-We would love submissions to either the Docs or Sample code! To contribute, first sign our CLA that can be found [here](https://tableau.github.io/contributing.html).  To submit a contribution, please fork the repository then submit a pull request to the `submissions` branch.
+Before we can accept pull requests from contributors, we require a signed [Contributor License Agreement (CLA)](https://tableau.github.io/contributing.html). To submit a contribution, please fork the repository then submit a pull request to the `main` branch.
 
 ## Code Style
 Our sample code follows the [Semi-Standard Style](https://github.com/Flet/semistandard) for JavaScript samples linting and [tslint](https://palantir.github.io/tslint/) for TypeScript.  If you add your own extension code to the Samples or Samples-Typescript directories, you can run `npm run lint` to validate the style of your code.  Please run this command before submitting any pull requests for Sample code.
 
-## Contributions
-Code contributions and improvements by the community are welcomed!
-See the LICENSE file for current open-source licensing and use information.
-
-Before we can accept pull requests from contributors, we require a signed [Contributor License Agreement (CLA)](http://tableau.github.io/contributing.html).
-
 ## Documentation
 [Visit the project website and read the documentation here.](https://tableau.github.io/extensions-api/)
 
-
 ## Issues
-Use [Issues](https://github.com/tableau/ProjectFrelard/issues) to log any problems or bugs you encounter in the docs or sample  code. 
+Use [Issues](https://github.com/tableau/extensions-api/issues) to log any problems or bugs you encounter in the docs or sample code, or to discuss any proposed changes or additions.

--- a/_includes/docs_menu.html
+++ b/_includes/docs_menu.html
@@ -91,7 +91,7 @@
             <a href="{{ site.baseurl }}/docs/index.html" target="_blank">API Reference</a>
         </li>
         <li>
-            <a href="{{ site.baseurl }}/docs/trex_tableau_viz_ref.html" target="_blank">Tableau Viz Reference</a>
+            <a href="{{ site.baseurl }}/docs/trex_tableau_viz_ref.html">Tableau Viz Reference</a>
         </li>
 		 <li>
             <a href="{{ site.baseurl }}/docs/trex_release-notes.html">Release Notes</a>

--- a/_includes/guide_menu.html
+++ b/_includes/guide_menu.html
@@ -30,7 +30,7 @@
         <li class="nav-header">Deploying your Extension</li>
         <li>
         <li>
-            <a href="{{ site.baseurl }}/docs/ux_extension_gallery.html">Submitting your Extension to the Extension Gallery</a>
+            <a href="{{ site.baseurl }}/docs/ux_extension_gallery.html">Submitting your Extension to the Tableau Exchange</a>
         </li>
 
     </ul>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,7 +22,7 @@
             <li><a href="{{ site.baseurl }}/docs/trex_release-notes.html">Release Notes</a></li>
           </ul>
           <ul class="nav navbar-nav navbar-right">
-            <li class="tableauIcon"><a target="_blank" href="http://tableau.com"><img src="{{ site.baseurl }}/assets/logo.png" alt="Tableau Developers" class="logo" /></a></li>
+            <li class="tableauIcon"><a target="_blank" href="http://tableau.com/developer"><img src="{{ site.baseurl }}/assets/logo.png" alt="Tableau Developers" class="logo" /></a></li>
             <li><a target="_blank" href="https://github.com/tableau/extensions-api"><span class="icon icon--github" title="Extensions API on GitHub" alt="Extensions API on GitHub">{% include icon-github.svg %}</span></a></li>
           </ul>
         </div><!--/.nav-collapse -->

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -17,9 +17,9 @@ layout: docs
         <div class="content .col-xs-12 .col-sm-8 .col-md-9">
             <h1>{{ page.title }}</h1>
             <div class="edit-container">
-                <a href="https://github.com/tableau/projectfrelard/edit/master/{{ page.path }}" class="edit-links"><span class="glyphicon glyphicon-pencil"></span> Edit this page</a>
+                <a href="https://github.com/tableau/extensions-api/edit/main/{{ page.path }}" class="edit-links"><span class="glyphicon glyphicon-pencil"></span> Edit this page</a>
                 &nbsp;
-                <a href="https://github.com/tableau/projectfrelard/issues" class="edit-links"><span class="glyphicon glyphicon-flag"></span> Submit an issue</a>
+                <a href="https://github.com/tableau/extensions-api/issues" class="edit-links"><span class="glyphicon glyphicon-flag"></span> Submit an issue</a>
             </div>
             <br />
 

--- a/_layouts/guide.html
+++ b/_layouts/guide.html
@@ -17,9 +17,9 @@ layout: guide
         <div class="content .col-xs-12 .col-sm-8 .col-md-9">
             <h1>{{ page.title }}</h1>
             <div class="edit-container">
-                <a href="https://github.com/tableau/projectfrelard/edit/master/{{ page.path }}" class="edit-links"><span class="glyphicon glyphicon-pencil"></span> Edit this page</a>
+                <a href="https://github.com/tableau/extensions-api/edit/main/{{ page.path }}" class="edit-links"><span class="glyphicon glyphicon-pencil"></span> Edit this page</a>
                 &nbsp;
-                <a href="https://github.com/tableau/projectfrelard/issues" class="edit-links"><span class="glyphicon glyphicon-flag"></span> Submit an issue</a>
+                <a href="https://github.com/tableau/extensions-api/issues" class="edit-links"><span class="glyphicon glyphicon-flag"></span> Submit an issue</a>
             </div>
             <br />
 

--- a/docs/Interaction_Guidelines/ux_build_test.md
+++ b/docs/Interaction_Guidelines/ux_build_test.md
@@ -13,7 +13,7 @@ This section serves as a broad overview of the developer experience and consider
 &nbsp;
 
 ## Build
-The first thing to do is start running sample extension code from the Extensions API Documentation. **Make sure that your sample code works** and your environment is set up properly before jumping into building a new extension. 
+The first thing to do is start running sample extension code from the Extensions API Documentation. **Make sure that your sample code works** and your environment is set up properly before jumping into building a new extension.
 
 Once you're ready to go, you can start building and customizing your extension. Expect to iterate through cycles of developing and designing your extension using our API documentation and these design guidelines.
 
@@ -23,9 +23,9 @@ Once you're ready to go, you can start building and customizing your extension. 
 
 * [Community Forums](https://community.tableau.com/community/developers/extensions-api/overview)<br>Participate in a community of developers that are passionate about creating extensions.
 
-* [Extension Gallery (beta)](https://extensiongallery.tableau.com/)<br>Explore and use some of the extensions our partners have created.
+* [Tableau Exchange](https://exchange.tableau.com/)<br>Explore and use some of the extensions our partners have created.
 
-* [Developer Preview](https://prerelease.tableau.com/extensions-api)<br>Participate in the Developer Preview for our Extensions API. Be invited to bi-weekly sprint demos with Tableau's development team and have the opportunity to give ongoing feedback.
+* [Tableau Developer Program](https://www.tableau.com/developer)<br>Participate in the Tableau Developer Program. Be invited to monthly sprint demos with Tableau's development team and have the opportunity to give ongoing feedback.
 
 &nbsp;
 

--- a/docs/trex_api_about.md
+++ b/docs/trex_api_about.md
@@ -24,7 +24,7 @@ The `extensions` name space has one method `initializeAsync()` that is used to i
 
 ## Registering and accessing dashboard extensions
 
-The dashboard extension is one type of extension in the Tableau extensions namespace (and it is accessed using `tableau.extensions`). To register the extension, you declare the type of extension in the manifest file (`.trex`). For more information about what goes in the file, see [Tableau Manifest File]({{site.baseurl}}\docs\index.html). 
+The dashboard extension is one type of extension in the Tableau extensions namespace (and it is accessed using `tableau.extensions`). To register the extension, you declare the type of extension in the manifest file (`.trex`). For more information about what goes in the file, see [Tableau Manifest File]({{site.baseurl}}\docs\trex_manifest.html). 
 
 ```xml
     <dashboard-extension id="com.example.extensions.name" extension-version="0.1.0">
@@ -37,7 +37,7 @@ To access the objects in the dashboard, you specify the namespace reserved for d
    const worksheets = tableau.extensions.dashboardContent.dashboard.worksheets ;
 ```
 
-The following diagram shows an outline of the namespace hierarchy that you traverse to get to worksheets.     
+The following diagram shows an outline of the namespace hierarchy that you traverse to get to worksheets.
 
 ![]({{site.baseurl}}/assets/tab_ext_class_worksheet.png)
 
@@ -49,11 +49,13 @@ For example, after you extract a worksheet object from the dashboard, you can us
 
 The following code fragment shows an example of setting an event listener `addEventListener` on a worksheet. 
 
-```python
-
+```javascript
     // Add an event listener for the selection changed event on this sheet.
-    unregisterEventHandlerFunction = worksheet.addEventListener('mark-selection-changed', myfunctionHandleSelectionEvent);
-``` 
+    // Assigning the event type to a variable just to make the example fit on the page here.
+    const markSelection = tableau.TableauEventType.MarkSelectionChanged;
+    let unregisterEventHandlerFunction = worksheet.addEventListener( markSelection, myfunctionHandleSelectionEvent);
+
+```
 
 
 

--- a/docs/trex_create.md
+++ b/docs/trex_create.md
@@ -172,18 +172,17 @@ Your web application must include an HTML page. This page should link to the Ext
 
 After you have created the manifest file (`.trex`) and have hosted your web app you can test it in Tableau. It's a good idea to do this even if your application isn't completed.
 
-
 1. Start up your web page or application (or make sure it is running).
 
-2. Start Tableau and open a workbook with a dashboard or create a new dashboard.
-3. In the dashboard, under **Objects**, select **Extension** and drag it on to the dashboard. In the **Choose an Extension** dialog box, click **My Extensions** and browse to directory where you have your manifest file.
+2. Start Tableau and open a workbook with a dashboard, or create a new dashboard with at least one worksheet.
+
+3. In the dashboard, under **Objects**, select **Extension** and drag it on to the dashboard. In the **Add an Extension** dialog box, click **Access Local Extensions** and browse to directory where you have your manifest file.
 
    After you select the manifest file, your web page should appear in the dashboard zone.
 
    - If not, and you see a 404 error, verify that you specified the correct URL to serve the page in the `.trex` file.
 
    - Tableau parses the `.trex` file when you add the extension to the dashboard. If you make changes to the `.trex` file after you have added it to the dashboard, you need to remove the extension and re-add it. See [What Happens When you Reload an Extension]({{site.baseurl}}/docs/trex_reload.html)
-
 
 ---
 

--- a/docs/trex_error_handling.md
+++ b/docs/trex_error_handling.md
@@ -20,7 +20,7 @@ As you create your extension, you want to be sure to catch potential error condi
 
 ## Handle extensions.ui dialog box errors
 
-For an example of how to handle an extension dialog box error, see the [UINamepace](https://github.com/tableau/extensions-api/tree/master/Samples/UINamepace?=target="_blank") sample. The sample shows how you could handle the error condition that occurs if a user dismisses a modal dialog box (`DialogClosedByUser`). In this extension, the user is expected to click the **Start Auto Refresh** button, which saves the configuration settings and closes the dialog box, by calling the `tableau.extensions.ui.closeDialog()` method with the return payload. If a user clicks the dialog box control (the **X** in the upper-right corner) instead, the error occurs. The following snippet illustrates how you could handle this error: 
+For an example of how to handle an extension dialog box error, see the [UINamespace](https://github.com/tableau/extensions-api/tree/master/Samples/UINamespace) sample. The sample shows how you could handle the error condition that occurs if a user dismisses a modal dialog box (`DialogClosedByUser`). In this extension, the user is expected to click the **Start Auto Refresh** button, which saves the configuration settings and closes the dialog box, by calling the `tableau.extensions.ui.closeDialog()` method with the return payload. If a user clicks the dialog box control (the **X** in the upper-right corner) instead, the error occurs. The following snippet illustrates how you could handle this error: 
 
 ```javascript
 

--- a/docs/trex_getstarted.md
+++ b/docs/trex_getstarted.md
@@ -9,7 +9,7 @@ The Tableau Dashboard Extensions API allows developers to create extensions for 
  
 This section will take you through the process of setting up your environment to use one of the sample dashboard extensions. Using one of the sample extensions is a great way to learn and great way to get started developing your own extensions. In this section, you will start a simple web server on your computer to host the sample. You can use the same process for hosting the extension when you start developing your own.
 
-<div class="alert alert-info"><p><b>Note</b> If you are looking for information about how to add an extension to a dashboard in Tableau, see <a href="https://onlinehelp.tableau.com/current/pro/desktop/en-us/dashboard_extensions.htm" target="_blank" ref="noopener">Use Dashboard Extensions</a>. If you are looking for extensions that you can use, see the <a href="https://extensiongallery.tableau.com/" target="_blank" ref="noopener">Tableau Extension Gallery</a>.</p>
+<div class="alert alert-info"><p><b>Note</b> If you are looking for information about how to add an extension to a dashboard in Tableau, see <a href="https://onlinehelp.tableau.com/current/pro/desktop/en-us/dashboard_extensions.htm" target="_blank" ref="noopener">Use Dashboard Extensions</a>. If you are looking for extensions that you can use, see the <a href="https://exchange.tableau.com/" target="_blank" ref="noopener">Tableau Exchange</a>.</p>
 </div>
 
 
@@ -91,13 +91,13 @@ To use the dashboard extension samples, you need to start up a web server on you
 ---
 ### Start Tableau and add an extension to the dashboard
 
-1. Start Tableau and open a workbook that has a dashboard, or open a workbook and create a new dashboard.
+1. Start Tableau and open a workbook that has a dashboard, or open a workbook and create a new dashboard with at least one worksheet.
 
 2. In the dashboard, under **Objects**, select **Extension** and drag it on to the dashboard.
 
    ![]({{site.baseurl}}/assets/frelard_objects_extension.png){:height="25%" width="25%"}
 
-3. In the **Choose an Extension** dialog box, click **My Extensions**.
+3. In the **Add an Extension** dialog box, click **Access Local Extensions**.
    Every Tableau extension has a manifest file (`.trex`) that describes the extension and identifies the location of the web application.
 
 4. Browse to the directory where the samples are located. For example, if you downloaded or cloned the GitHub repository, go to `\extensions-api\Samples\DataSources`.

--- a/docs/trex_publish.md
+++ b/docs/trex_publish.md
@@ -50,11 +50,11 @@ The following flowchart shows how the settings on Tableau Server or Tableau Onli
 
 
 
-## Publishing a dashboard extension to the Extension Gallery
+## Publishing a dashboard extension to the Tableau Exchange
 
-If you want to make your dashboard extension readily available to a large number of people, you can take steps to have your extension added to the [Tableau Extension Gallery](https://extensiongallery.tableau.com/).
+If you want to make your dashboard extension readily available to a large number of people, you can take steps to have your extension added to the [Tableau Exchange](https://exchange.tableau.com/).
 
-Publishing your extension to the gallery means that people will be able to discover your extension, find out what it can do, and then add the extension to their dashboards, all while working within Tableau.
+Publishing your extension to the Tableau Exchange means that people will be able to discover your extension, find out what it can do, and then add the extension to their dashboards, all while working within Tableau.
 
 In addition to the requirements for all extensions to ensure security and usability, such as:
  * Using HTTPS
@@ -62,12 +62,12 @@ In addition to the requirements for all extensions to ensure security and usabil
  * Declaring data access requirements
  * Providing a URL that customers can use to get support for your the extension
  
- Dashboard extensions that appear in the gallery must also:
+ Dashboard extensions that appear in the Tableau Exchange must also:
 
 * Follow the Design Guidelines for Dashboard Extensions (user interaction and style guidelines for user interface elements).
-* Ensure that the information in the extension manifest file (`.trex`) matches the content that you will publish in the Extension Gallery. For example, the `name`, `description` fields are used to populate the name and description fields in the Extension Gallery.  The icon you use in the manifest should also be the icon that is used in the gallery. You need to provide a 280x280 pixel `.png` version of the icon. 
+* Ensure that the information in the extension manifest file (`.trex`) matches the content that you will publish in the Tableau Exchange. For example, the `name`, `description` fields are used to populate the name and description fields in the Tableau Exchange.  The icon you use in the manifest should also be the icon that is used in the Tableau Exchange. You need to provide a 280x280 pixel `.png` version of the icon. 
 
-For information about getting your extension into the Extension Gallery, see [Submitting your Extension to the Extension Gallery]({{site.baseurl}}/docs/ux_extension_gallery.html){:target="_blank"}.
+For information about getting your extension into the Tableau Exchange, see [Submitting your Extension to the Tableau Exchange]({{site.baseurl}}/docs/ux_extension_gallery.html){:target="_blank"}.
 
 For information about designing an extension, see [Design Guidelines for Dashboard Extensions]({{site.baseurl}}/docs/ux_design.html){:target="_blank"}.
 

--- a/docs/trex_sandbox_publish.md
+++ b/docs/trex_sandbox_publish.md
@@ -3,9 +3,7 @@ title: Publish Sandboxed Extensions
 layout: docs
 ---
 
-> *\*\* This is preliminary information and is subject to change \*\**
-
-Sandboxed Extensions are Tableau dashboard extensions that are not permitted to make external network requests. Sandboxed Extensions are hosted by Tableau and run inside an environment that prevents communication with anything except the Tableau hosting server. Sandboxed Extensions are supported in Tableau 2019.4 and later. Available for testing with Tableau 2019.3.
+Sandboxed Extensions are Tableau dashboard extensions that are not permitted to make external network requests. Sandboxed Extensions are hosted by Tableau and run inside an environment that prevents communication with anything except the Tableau hosting server. Sandboxed Extensions are supported in Tableau 2019.4 and later.
 
 ## Before publishing your extension
 
@@ -14,12 +12,12 @@ Be sure to follow the guidelines and requirements to [Create and Test Sandboxed 
 
 ## Submit your Sandboxed Extension for publication
 
-After you finish developing and testing your Sandboxed Extension, fill out the [Extension Gallery Submission form](https://tabsoft.co/gallerysubmit){:target="_blank"}{:ref="noopener"} with your information and details about your extension.
-For information about what goes in the form, see [Submitting your Extension to the Extension Gallery]({{site.baseurl}}/docs/ux_extension_gallery.html){:target="_blank"}.
+After you finish developing and testing your Sandboxed Extension, fill out the [Tableau Exchange Submission form](https://tabsoft.co/gallerysubmit){:target="_blank"}{:ref="noopener"} with your information and details about your extension.
+For information about what goes in the form, see [Submitting your Extension to the Tableau Exchange]({{site.baseurl}}/docs/ux_extension_gallery.html){:target="_blank"}.
 
 Our developers from the Developer Platform team at Tableau will let you know the next steps including legal agreements after you submit your information. If you have any questions about the gallery please send them to [extensiongallery@tableau.com](extensiongallery@tableau.com){:target="_blank"}{:ref="noopener"}.
 
-Once accepted, Tableau will publish your extension and your extension will be available in the [Extensions Gallery](https://extensiongallery.tableau.com/){:target="_blank"}{:ref="noopener"}.  
+Once accepted, Tableau will publish your extension and your extension will be available in the [Tableau Exchange](https://extensiongallery.tableau.com/){:target="_blank"}{:ref="noopener"}.  
 
 
 

--- a/docs/trex_sandbox_test.md
+++ b/docs/trex_sandbox_test.md
@@ -22,7 +22,7 @@ Tableau supports two types of dashboard extensions:
 
 * **Network Enabled Extensions** - can access resources and applications outside of Tableau. Supported in Tableau 2018.2 and later.
 
-* **Sandboxed Extensions** - run in a Tableau hosted environment and cannot make network calls. Supported in Tableau 2019.4 and later. Available for testing with Tableau 2019.3.
+* **Sandboxed Extensions** - run in a Tableau hosted environment and cannot make network calls. Supported in Tableau 2019.4 and later.
 
 
 ## Create Sandboxed Extensions

--- a/docs/trex_tableau_viz_ref.md
+++ b/docs/trex_tableau_viz_ref.md
@@ -147,7 +147,7 @@ Within these properties, you must specify the field to encode and its type (`tab
 |`type`| The type of field, either `tableau.VizImageEncodingType.Discrete` (blue "pill") or `tableau.VizImageEncodingType.Continuous` (green "pill"). |
 |`hidden` | Boolean (`true`, `false`). Specifies whether to show or hide the column or row header. |
 | `showgridline` | Boolean (`true`, `false`). Specifies whether to show or hide the gridlines. |
-|`title` | Specifies a custom field label (x-axis, or header) or custom axis title (y-axis) for the columns and rows. |
+|`title` | Specifies a custom label (x-axis, or header) or custom axis title (y-axis) for the columns and rows. A `title` can only be used for continuous fields (`tableau.VizImageEncodingType.Continuous`). Custom titles for discrete fields are not supported. |
 | `showtitle` | Boolean (`true`, `false`). Specifies whether to show or hide the custom column or row title. |
 
 The following are examples of how you might specify the encodings for columns and rows:
@@ -155,7 +155,7 @@ The following are examples of how you might specify the encodings for columns an
 ```javascript
 
 encoding: {
-  columns: {field: "Sales", type: tableau.VizImageEncodingType.Continuous, title: "My Custom Title", showtitle: false},
+  columns: {field: "Sales", type: tableau.VizImageEncodingType.Continuous, title: "My Custom Title", showtitle: true},
   rows: {field: "Category", type: tableau.VizImageEncodingType.Discrete  }
 } 
 

--- a/docs/ux_extension_gallery.md
+++ b/docs/ux_extension_gallery.md
@@ -1,18 +1,18 @@
 ---
-title: Submitting your Extension to the Extension Gallery
+title: Submitting your Extension to the Tableau Exchange
 layout: guide
 ---
 
 
-You may be interested in sharing your extension for others to download and use in their dashboards. To submit to our [Extension Gallery](https://extensiongallery.tableau.com/) online, make sure you have the following components gathered. 
+You may be interested in sharing your extension for others to download and use in their dashboards. To submit your extension to the [Tableau Exchange](https://extensiongallery.tableau.com/) online, make sure you have the following components gathered.
 
-**[Gallery Card](#gallery-card-example)**
+**[Exchange Card](#exchange-card-example)**
 
 * Extension Name
 * Extension Icon
 * Tagline
 
-**[Gallery Page](#gallery-page-example)**
+**[Exchange Page](#exchange-page-example)**
 
 * Description
 * Developer Info
@@ -24,7 +24,7 @@ You may be interested in sharing your extension for others to download and use i
 
 ---
 
-## Gallery Card Example
+## Exchange Card Example
 This is what an extension looks like to a user while browsing the Extension Gallery. 
 
 ![gallery card example](imgs/gallery_card_example.png)
@@ -38,7 +38,7 @@ This is what an extension looks like to a user while browsing the Extension Gall
 
 &nbsp; 
 
-## Gallery Page Example
+## Exchange Page Example
 Users reach pages like this when they want to know more about a particular extension. 
 
 ![gallery page example](imgs/gallery_page_example.png)
@@ -53,4 +53,4 @@ Users reach pages like this when they want to know more about a particular exten
 
 ## How to Submit your Extension
 
-After completing your extension, fill out the [Extension Gallery Submission form](https://tabsoft.co/gallerysubmit){:target="_blank"}{:ref="noopener"} with your information and extension details. The extension name in the template needs to match the name you specified for your extension in the manifest file (`.trex`). The 280x280 pixel `.png` icon that you attach with your submission must look like the icon you included in your manifest file (they just have different dimensions). Our developers from the Developer Platform team at Tableau will let you know the next steps including legal agreements after you submit. If you have any questions about the gallery please send them to [extensiongallery@tableau.com](extensiongallery@tableau.com){:target="_blank"}{:ref="noopener"}.
+After completing your extension, fill out the [Tableau Exchange Submission form](https://tabsoft.co/gallerysubmit){:target="_blank"}{:ref="noopener"} with your information and extension details. The extension name in the template needs to match the name you specified for your extension in the manifest file (`.trex`). The 280x280 pixel `.png` icon that you attach with your submission must look like the icon you included in your manifest file (they just have different dimensions). Our developers from the Developer Platform team at Tableau will let you know the next steps including legal agreements after you submit. If you have any questions about the Tableau Exchange please send them to [extensiongallery@tableau.com](mailto:extensiongallery@tableau.com).


### PR DESCRIPTION
In this pull request:

* clarified custom titles only work on continuous fields (VizAPI) TFSID:1362792
* changed Extension Gallery references to Tableau Exchange
* implemented @bcantoni edits for `projectfrelard`, Readme.md, and misc broken links and typos.