### PR TITLE
Adding new GA4 ID to test if it works for conceptual pages

### DIFF
--- a/website/docs/trex_api_about.md
+++ b/website/docs/trex_api_about.md
@@ -171,4 +171,3 @@ classDiagram
 
 
 
-

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -104,7 +104,7 @@ const getConfig = async () => {
            {
               label: 'Community Extensions',
               to: 'pathname:///community',
-            }  
+            },  
          /*   {
               type: 'docSidebar',
               position: 'left',
@@ -212,7 +212,8 @@ const getConfig = async () => {
         [
           '@docusaurus/plugin-google-gtag',
           {
-            trackingID: 'UA-625217-51',
+            // trackingID: 'UA-625217-51',
+            trackingID: '376609887',
             anonymizeIP: true,
           },
         ],
@@ -244,27 +245,9 @@ const getConfig = async () => {
           },
         ],  */
 
-      //    '@cmfcmf/docusaurus-search-local',
-      /*  [
-          require.resolve("@easyops-cn/docusaurus-search-local"),
-         // /** @type {import("@easyops-cn/docusaurus-search-local").PluginOptions} 
-          ({
-            // ... Your options.
-            // `hashed` is recommended as long-term-cache of index file is possible.
-            hashed: true,
-            // For Docs using Chinese, The `language` is recommended to set to:
-            // ```
-            // language: ["en", "zh"],
-            // ```
-          }),  
-          ], */
       ],
 
-      markdown: {
-
-        mermaid: true,
-
-      },
+  
       themes: [
         
         '@docusaurus/theme-mermaid',
@@ -285,7 +268,13 @@ const getConfig = async () => {
           // ```
         }),
         ],
-      ]
+      ],
+      
+      markdown: {
+
+        mermaid: true,
+
+      },
   };
 }
 

--- a/website/package.json
+++ b/website/package.json
@@ -19,11 +19,11 @@
   },
   "dependencies": {
     "@babel/helper-explode-assignable-expression": "^7.18.6",
-    "@docusaurus/core": "^3.3.2",
-    "@docusaurus/plugin-google-tag-manager": "^3.3.2",
-    "@docusaurus/preset-classic": "^3.3.2",
-    "@docusaurus/theme-mermaid": "^3.3.2",
-    "@docusaurus/utils-validation": "^3.3.2",
+    "@docusaurus/core": "^3.4.0",
+    "@docusaurus/plugin-google-tag-manager": "^3.4.0",
+    "@docusaurus/preset-classic": "^3.4.0",
+    "@docusaurus/theme-mermaid": "^3.4.0",
+    "@docusaurus/utils-validation": "^3.4.0",
     "@easyops-cn/docusaurus-search-local": "^0.40.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^1.2.1",
@@ -36,8 +36,8 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.3.2",
-    "@docusaurus/types": "^3.3.2",
+    "@docusaurus/module-type-aliases": "^3.4.0",
+    "@docusaurus/types": "^3.4.0",
     "@tsconfig/docusaurus": "^1.0.5",
     "prettier": "^2.8.4",
     "ts-node": "^10.9.1",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2048,7 +2048,7 @@
     "@docsearch/css" "3.6.0"
     algoliasearch "^4.19.1"
 
-"@docusaurus/core@3.3.2", "@docusaurus/core@^3.3.2":
+"@docusaurus/core@3.3.2":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-3.3.2.tgz#67b8cd5329b32f47515ecf12eb7aa306dfc69922"
   integrity sha512-PzKMydKI3IU1LmeZQDi+ut5RSuilbXnA8QdowGeJEgU8EJjmx3rBHNT1LxQxOVqNEwpWi/csLwd9bn7rUjggPA==
@@ -2122,6 +2122,80 @@
     webpack-merge "^5.9.0"
     webpackbar "^5.0.2"
 
+"@docusaurus/core@3.4.0", "@docusaurus/core@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-3.4.0.tgz#bdbf1af4b2f25d1bf4a5b62ec6137d84c821cb3c"
+  integrity sha512-g+0wwmN2UJsBqy2fQRQ6fhXruoEa62JDeEa5d8IdTJlMoaDaEDfHh7WjwGRn4opuTQWpjAwP/fbcgyHKlE+64w==
+  dependencies:
+    "@babel/core" "^7.23.3"
+    "@babel/generator" "^7.23.3"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+    "@babel/plugin-transform-runtime" "^7.22.9"
+    "@babel/preset-env" "^7.22.9"
+    "@babel/preset-react" "^7.22.5"
+    "@babel/preset-typescript" "^7.22.5"
+    "@babel/runtime" "^7.22.6"
+    "@babel/runtime-corejs3" "^7.22.6"
+    "@babel/traverse" "^7.22.8"
+    "@docusaurus/cssnano-preset" "3.4.0"
+    "@docusaurus/logger" "3.4.0"
+    "@docusaurus/mdx-loader" "3.4.0"
+    "@docusaurus/utils" "3.4.0"
+    "@docusaurus/utils-common" "3.4.0"
+    "@docusaurus/utils-validation" "3.4.0"
+    autoprefixer "^10.4.14"
+    babel-loader "^9.1.3"
+    babel-plugin-dynamic-import-node "^2.3.3"
+    boxen "^6.2.1"
+    chalk "^4.1.2"
+    chokidar "^3.5.3"
+    clean-css "^5.3.2"
+    cli-table3 "^0.6.3"
+    combine-promises "^1.1.0"
+    commander "^5.1.0"
+    copy-webpack-plugin "^11.0.0"
+    core-js "^3.31.1"
+    css-loader "^6.8.1"
+    css-minimizer-webpack-plugin "^5.0.1"
+    cssnano "^6.1.2"
+    del "^6.1.1"
+    detect-port "^1.5.1"
+    escape-html "^1.0.3"
+    eta "^2.2.0"
+    eval "^0.1.8"
+    file-loader "^6.2.0"
+    fs-extra "^11.1.1"
+    html-minifier-terser "^7.2.0"
+    html-tags "^3.3.1"
+    html-webpack-plugin "^5.5.3"
+    leven "^3.1.0"
+    lodash "^4.17.21"
+    mini-css-extract-plugin "^2.7.6"
+    p-map "^4.0.0"
+    postcss "^8.4.26"
+    postcss-loader "^7.3.3"
+    prompts "^2.4.2"
+    react-dev-utils "^12.0.1"
+    react-helmet-async "^1.3.0"
+    react-loadable "npm:@docusaurus/react-loadable@6.0.0"
+    react-loadable-ssr-addon-v5-slorber "^1.0.1"
+    react-router "^5.3.4"
+    react-router-config "^5.1.1"
+    react-router-dom "^5.3.4"
+    rtl-detect "^1.0.4"
+    semver "^7.5.4"
+    serve-handler "^6.1.5"
+    shelljs "^0.8.5"
+    terser-webpack-plugin "^5.3.9"
+    tslib "^2.6.0"
+    update-notifier "^6.0.2"
+    url-loader "^4.1.1"
+    webpack "^5.88.1"
+    webpack-bundle-analyzer "^4.9.0"
+    webpack-dev-server "^4.15.1"
+    webpack-merge "^5.9.0"
+    webpackbar "^5.0.2"
+
 "@docusaurus/cssnano-preset@3.3.2":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-3.3.2.tgz#fb971b3e89fe6821721782124b430b2795faeb38"
@@ -2132,10 +2206,28 @@
     postcss-sort-media-queries "^5.2.0"
     tslib "^2.6.0"
 
+"@docusaurus/cssnano-preset@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-3.4.0.tgz#dc7922b3bbeabcefc9b60d0161680d81cf72c368"
+  integrity sha512-qwLFSz6v/pZHy/UP32IrprmH5ORce86BGtN0eBtG75PpzQJAzp9gefspox+s8IEOr0oZKuQ/nhzZ3xwyc3jYJQ==
+  dependencies:
+    cssnano-preset-advanced "^6.1.2"
+    postcss "^8.4.38"
+    postcss-sort-media-queries "^5.2.0"
+    tslib "^2.6.0"
+
 "@docusaurus/logger@3.3.2":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/logger/-/logger-3.3.2.tgz#f43f7e08d4f5403be6a7196659490053e248325f"
   integrity sha512-Ldu38GJ4P8g4guN7d7pyCOJ7qQugG7RVyaxrK8OnxuTlaImvQw33aDRwaX2eNmX8YK6v+//Z502F4sOZbHHCHQ==
+  dependencies:
+    chalk "^4.1.2"
+    tslib "^2.6.0"
+
+"@docusaurus/logger@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/logger/-/logger-3.4.0.tgz#8b0ac05c7f3dac2009066e2f964dee8209a77403"
+  integrity sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==
   dependencies:
     chalk "^4.1.2"
     tslib "^2.6.0"
@@ -2170,7 +2262,37 @@
     vfile "^6.0.1"
     webpack "^5.88.1"
 
-"@docusaurus/module-type-aliases@3.3.2", "@docusaurus/module-type-aliases@^3.3.2":
+"@docusaurus/mdx-loader@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-3.4.0.tgz#483d7ab57928fdbb5c8bd1678098721a930fc5f6"
+  integrity sha512-kSSbrrk4nTjf4d+wtBA9H+FGauf2gCax89kV8SUSJu3qaTdSIKdWERlngsiHaCFgZ7laTJ8a67UFf+xlFPtuTw==
+  dependencies:
+    "@docusaurus/logger" "3.4.0"
+    "@docusaurus/utils" "3.4.0"
+    "@docusaurus/utils-validation" "3.4.0"
+    "@mdx-js/mdx" "^3.0.0"
+    "@slorber/remark-comment" "^1.0.0"
+    escape-html "^1.0.3"
+    estree-util-value-to-estree "^3.0.1"
+    file-loader "^6.2.0"
+    fs-extra "^11.1.1"
+    image-size "^1.0.2"
+    mdast-util-mdx "^3.0.0"
+    mdast-util-to-string "^4.0.0"
+    rehype-raw "^7.0.0"
+    remark-directive "^3.0.0"
+    remark-emoji "^4.0.0"
+    remark-frontmatter "^5.0.0"
+    remark-gfm "^4.0.0"
+    stringify-object "^3.3.0"
+    tslib "^2.6.0"
+    unified "^11.0.3"
+    unist-util-visit "^5.0.0"
+    url-loader "^4.1.1"
+    vfile "^6.0.1"
+    webpack "^5.88.1"
+
+"@docusaurus/module-type-aliases@3.3.2":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-3.3.2.tgz#02534449d08d080fd52dc9e046932bb600c38b01"
   integrity sha512-b/XB0TBJah5yKb4LYuJT4buFvL0MGAb0+vJDrJtlYMguRtsEBkf2nWl5xP7h4Dlw6ol0hsHrCYzJ50kNIOEclw==
@@ -2183,18 +2305,31 @@
     react-helmet-async "*"
     react-loadable "npm:@docusaurus/react-loadable@6.0.0"
 
-"@docusaurus/plugin-content-blog@3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.3.2.tgz#6496714b071447687ead1472e5756bfb1ae065d0"
-  integrity sha512-fJU+dmqp231LnwDJv+BHVWft8pcUS2xVPZdeYH6/ibH1s2wQ/sLcmUrGWyIv/Gq9Ptj8XWjRPMghlxghuPPoxg==
+"@docusaurus/module-type-aliases@3.4.0", "@docusaurus/module-type-aliases@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-3.4.0.tgz#2653bde58fc1aa3dbc626a6c08cfb63a37ae1bb8"
+  integrity sha512-A1AyS8WF5Bkjnb8s+guTDuYmUiwJzNrtchebBHpc0gz0PyHJNMaybUlSrmJjHVcGrya0LKI4YcR3lBDQfXRYLw==
   dependencies:
-    "@docusaurus/core" "3.3.2"
-    "@docusaurus/logger" "3.3.2"
-    "@docusaurus/mdx-loader" "3.3.2"
-    "@docusaurus/types" "3.3.2"
-    "@docusaurus/utils" "3.3.2"
-    "@docusaurus/utils-common" "3.3.2"
-    "@docusaurus/utils-validation" "3.3.2"
+    "@docusaurus/types" "3.4.0"
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
+    "@types/react-router-config" "*"
+    "@types/react-router-dom" "*"
+    react-helmet-async "*"
+    react-loadable "npm:@docusaurus/react-loadable@6.0.0"
+
+"@docusaurus/plugin-content-blog@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.4.0.tgz#6373632fdbababbda73a13c4a08f907d7de8f007"
+  integrity sha512-vv6ZAj78ibR5Jh7XBUT4ndIjmlAxkijM3Sx5MAAzC1gyv0vupDQNhzuFg1USQmQVj3P5I6bquk12etPV3LJ+Xw==
+  dependencies:
+    "@docusaurus/core" "3.4.0"
+    "@docusaurus/logger" "3.4.0"
+    "@docusaurus/mdx-loader" "3.4.0"
+    "@docusaurus/types" "3.4.0"
+    "@docusaurus/utils" "3.4.0"
+    "@docusaurus/utils-common" "3.4.0"
+    "@docusaurus/utils-validation" "3.4.0"
     cheerio "^1.0.0-rc.12"
     feed "^4.2.2"
     fs-extra "^11.1.1"
@@ -2206,7 +2341,29 @@
     utility-types "^3.10.0"
     webpack "^5.88.1"
 
-"@docusaurus/plugin-content-docs@3.3.2", "@docusaurus/plugin-content-docs@^2 || ^3":
+"@docusaurus/plugin-content-docs@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.4.0.tgz#3088973f72169a2a6d533afccec7153c8720d332"
+  integrity sha512-HkUCZffhBo7ocYheD9oZvMcDloRnGhBMOZRyVcAQRFmZPmNqSyISlXA1tQCIxW+r478fty97XXAGjNYzBjpCsg==
+  dependencies:
+    "@docusaurus/core" "3.4.0"
+    "@docusaurus/logger" "3.4.0"
+    "@docusaurus/mdx-loader" "3.4.0"
+    "@docusaurus/module-type-aliases" "3.4.0"
+    "@docusaurus/types" "3.4.0"
+    "@docusaurus/utils" "3.4.0"
+    "@docusaurus/utils-common" "3.4.0"
+    "@docusaurus/utils-validation" "3.4.0"
+    "@types/react-router-config" "^5.0.7"
+    combine-promises "^1.1.0"
+    fs-extra "^11.1.1"
+    js-yaml "^4.1.0"
+    lodash "^4.17.21"
+    tslib "^2.6.0"
+    utility-types "^3.10.0"
+    webpack "^5.88.1"
+
+"@docusaurus/plugin-content-docs@^2 || ^3":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.3.2.tgz#dadfbb94acfb0b74fae12db51f425c4379e30087"
   integrity sha512-Dm1ri2VlGATTN3VGk1ZRqdRXWa1UlFubjaEL6JaxaK7IIFqN/Esjpl+Xw10R33loHcRww/H76VdEeYayaL76eg==
@@ -2228,114 +2385,114 @@
     utility-types "^3.10.0"
     webpack "^5.88.1"
 
-"@docusaurus/plugin-content-pages@3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.3.2.tgz#04fc18d1925618c1102b111b85e6376442c1b7a9"
-  integrity sha512-EKc9fQn5H2+OcGER8x1aR+7URtAGWySUgULfqE/M14+rIisdrBstuEZ4lUPDRrSIexOVClML82h2fDS+GSb8Ew==
+"@docusaurus/plugin-content-pages@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.4.0.tgz#1846172ca0355c7d32a67ef8377750ce02bbb8ad"
+  integrity sha512-h2+VN/0JjpR8fIkDEAoadNjfR3oLzB+v1qSXbIAKjQ46JAHx3X22n9nqS+BWSQnTnp1AjkjSvZyJMekmcwxzxg==
   dependencies:
-    "@docusaurus/core" "3.3.2"
-    "@docusaurus/mdx-loader" "3.3.2"
-    "@docusaurus/types" "3.3.2"
-    "@docusaurus/utils" "3.3.2"
-    "@docusaurus/utils-validation" "3.3.2"
+    "@docusaurus/core" "3.4.0"
+    "@docusaurus/mdx-loader" "3.4.0"
+    "@docusaurus/types" "3.4.0"
+    "@docusaurus/utils" "3.4.0"
+    "@docusaurus/utils-validation" "3.4.0"
     fs-extra "^11.1.1"
     tslib "^2.6.0"
     webpack "^5.88.1"
 
-"@docusaurus/plugin-debug@3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-3.3.2.tgz#bb25fac2cb705eff7857b435219faef907ba949e"
-  integrity sha512-oBIBmwtaB+YS0XlmZ3gCO+cMbsGvIYuAKkAopoCh0arVjtlyPbejzPrHuCoRHB9G7abjNZw7zoONOR8+8LM5+Q==
+"@docusaurus/plugin-debug@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-3.4.0.tgz#74e4ec5686fa314c26f3ac150bacadbba7f06948"
+  integrity sha512-uV7FDUNXGyDSD3PwUaf5YijX91T5/H9SX4ErEcshzwgzWwBtK37nUWPU3ZLJfeTavX3fycTOqk9TglpOLaWkCg==
   dependencies:
-    "@docusaurus/core" "3.3.2"
-    "@docusaurus/types" "3.3.2"
-    "@docusaurus/utils" "3.3.2"
+    "@docusaurus/core" "3.4.0"
+    "@docusaurus/types" "3.4.0"
+    "@docusaurus/utils" "3.4.0"
     fs-extra "^11.1.1"
     react-json-view-lite "^1.2.0"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-google-analytics@3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.3.2.tgz#6e51ee8593c79172ed2b2ac4d33e300f04bfbc87"
-  integrity sha512-jXhrEIhYPSClMBK6/IA8qf1/FBoxqGXZvg7EuBax9HaK9+kL3L0TJIlatd8jQJOMtds8mKw806TOCc3rtEad1A==
+"@docusaurus/plugin-google-analytics@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.4.0.tgz#5f59fc25329a59decc231936f6f9fb5663da3c55"
+  integrity sha512-mCArluxEGi3cmYHqsgpGGt3IyLCrFBxPsxNZ56Mpur0xSlInnIHoeLDH7FvVVcPJRPSQ9/MfRqLsainRw+BojA==
   dependencies:
-    "@docusaurus/core" "3.3.2"
-    "@docusaurus/types" "3.3.2"
-    "@docusaurus/utils-validation" "3.3.2"
+    "@docusaurus/core" "3.4.0"
+    "@docusaurus/types" "3.4.0"
+    "@docusaurus/utils-validation" "3.4.0"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-google-gtag@3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.3.2.tgz#f8126dfe1dfa6e722157d7301430da40b97354ba"
-  integrity sha512-vcrKOHGbIDjVnNMrfbNpRQR1x6Jvcrb48kVzpBAOsKbj9rXZm/idjVAXRaewwobHdOrJkfWS/UJoxzK8wyLRBQ==
+"@docusaurus/plugin-google-gtag@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.4.0.tgz#42489ac5fe1c83b5523ceedd5ef74f9aa8bc251b"
+  integrity sha512-Dsgg6PLAqzZw5wZ4QjUYc8Z2KqJqXxHxq3vIoyoBWiLEEfigIs7wHR+oiWUQy3Zk9MIk6JTYj7tMoQU0Jm3nqA==
   dependencies:
-    "@docusaurus/core" "3.3.2"
-    "@docusaurus/types" "3.3.2"
-    "@docusaurus/utils-validation" "3.3.2"
+    "@docusaurus/core" "3.4.0"
+    "@docusaurus/types" "3.4.0"
+    "@docusaurus/utils-validation" "3.4.0"
     "@types/gtag.js" "^0.0.12"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-google-tag-manager@3.3.2", "@docusaurus/plugin-google-tag-manager@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.3.2.tgz#7ce4cf4da6ef177d63bd83beafc4a45428ff01e2"
-  integrity sha512-ldkR58Fdeks0vC+HQ+L+bGFSJsotQsipXD+iKXQFvkOfmPIV6QbHRd7IIcm5b6UtwOiK33PylNS++gjyLUmaGw==
+"@docusaurus/plugin-google-tag-manager@3.4.0", "@docusaurus/plugin-google-tag-manager@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.4.0.tgz#cebb03a5ffa1e70b37d95601442babea251329ff"
+  integrity sha512-O9tX1BTwxIhgXpOLpFDueYA9DWk69WCbDRrjYoMQtFHSkTyE7RhNgyjSPREUWJb9i+YUg3OrsvrBYRl64FCPCQ==
   dependencies:
-    "@docusaurus/core" "3.3.2"
-    "@docusaurus/types" "3.3.2"
-    "@docusaurus/utils-validation" "3.3.2"
+    "@docusaurus/core" "3.4.0"
+    "@docusaurus/types" "3.4.0"
+    "@docusaurus/utils-validation" "3.4.0"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-sitemap@3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.3.2.tgz#f64fba6f03ebc14fdf55434aa2219bf80f752a13"
-  integrity sha512-/ZI1+bwZBhAgC30inBsHe3qY9LOZS+79fRGkNdTcGHRMcdAp6Vw2pCd1gzlxd/xU+HXsNP6cLmTOrggmRp3Ujg==
+"@docusaurus/plugin-sitemap@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.4.0.tgz#b091d64d1e3c6c872050189999580187537bcbc6"
+  integrity sha512-+0VDvx9SmNrFNgwPoeoCha+tRoAjopwT0+pYO1xAbyLcewXSemq+eLxEa46Q1/aoOaJQ0qqHELuQM7iS2gp33Q==
   dependencies:
-    "@docusaurus/core" "3.3.2"
-    "@docusaurus/logger" "3.3.2"
-    "@docusaurus/types" "3.3.2"
-    "@docusaurus/utils" "3.3.2"
-    "@docusaurus/utils-common" "3.3.2"
-    "@docusaurus/utils-validation" "3.3.2"
+    "@docusaurus/core" "3.4.0"
+    "@docusaurus/logger" "3.4.0"
+    "@docusaurus/types" "3.4.0"
+    "@docusaurus/utils" "3.4.0"
+    "@docusaurus/utils-common" "3.4.0"
+    "@docusaurus/utils-validation" "3.4.0"
     fs-extra "^11.1.1"
     sitemap "^7.1.1"
     tslib "^2.6.0"
 
-"@docusaurus/preset-classic@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-3.3.2.tgz#1c89b5f35f9e727a1c91bc03eb25a5b42b7d67a6"
-  integrity sha512-1SDS7YIUN1Pg3BmD6TOTjhB7RSBHJRpgIRKx9TpxqyDrJ92sqtZhomDc6UYoMMLQNF2wHFZZVGFjxJhw2VpL+Q==
+"@docusaurus/preset-classic@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-3.4.0.tgz#6082a32fbb465b0cb2c2a50ebfc277cff2c0f139"
+  integrity sha512-Ohj6KB7siKqZaQhNJVMBBUzT3Nnp6eTKqO+FXO3qu/n1hJl3YLwVKTWBg28LF7MWrKu46UuYavwMRxud0VyqHg==
   dependencies:
-    "@docusaurus/core" "3.3.2"
-    "@docusaurus/plugin-content-blog" "3.3.2"
-    "@docusaurus/plugin-content-docs" "3.3.2"
-    "@docusaurus/plugin-content-pages" "3.3.2"
-    "@docusaurus/plugin-debug" "3.3.2"
-    "@docusaurus/plugin-google-analytics" "3.3.2"
-    "@docusaurus/plugin-google-gtag" "3.3.2"
-    "@docusaurus/plugin-google-tag-manager" "3.3.2"
-    "@docusaurus/plugin-sitemap" "3.3.2"
-    "@docusaurus/theme-classic" "3.3.2"
-    "@docusaurus/theme-common" "3.3.2"
-    "@docusaurus/theme-search-algolia" "3.3.2"
-    "@docusaurus/types" "3.3.2"
+    "@docusaurus/core" "3.4.0"
+    "@docusaurus/plugin-content-blog" "3.4.0"
+    "@docusaurus/plugin-content-docs" "3.4.0"
+    "@docusaurus/plugin-content-pages" "3.4.0"
+    "@docusaurus/plugin-debug" "3.4.0"
+    "@docusaurus/plugin-google-analytics" "3.4.0"
+    "@docusaurus/plugin-google-gtag" "3.4.0"
+    "@docusaurus/plugin-google-tag-manager" "3.4.0"
+    "@docusaurus/plugin-sitemap" "3.4.0"
+    "@docusaurus/theme-classic" "3.4.0"
+    "@docusaurus/theme-common" "3.4.0"
+    "@docusaurus/theme-search-algolia" "3.4.0"
+    "@docusaurus/types" "3.4.0"
 
-"@docusaurus/theme-classic@3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-3.3.2.tgz#44489580e034a6f5b877ec8bfd1203e226b4a4ab"
-  integrity sha512-gepHFcsluIkPb4Im9ukkiO4lXrai671wzS3cKQkY9BXQgdVwsdPf/KS0Vs4Xlb0F10fTz+T3gNjkxNEgSN9M0A==
+"@docusaurus/theme-classic@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-3.4.0.tgz#1b0f48edec3e3ec8927843554b9f11e5927b0e52"
+  integrity sha512-0IPtmxsBYv2adr1GnZRdMkEQt1YW6tpzrUPj02YxNpvJ5+ju4E13J5tB4nfdaen/tfR1hmpSPlTFPvTf4kwy8Q==
   dependencies:
-    "@docusaurus/core" "3.3.2"
-    "@docusaurus/mdx-loader" "3.3.2"
-    "@docusaurus/module-type-aliases" "3.3.2"
-    "@docusaurus/plugin-content-blog" "3.3.2"
-    "@docusaurus/plugin-content-docs" "3.3.2"
-    "@docusaurus/plugin-content-pages" "3.3.2"
-    "@docusaurus/theme-common" "3.3.2"
-    "@docusaurus/theme-translations" "3.3.2"
-    "@docusaurus/types" "3.3.2"
-    "@docusaurus/utils" "3.3.2"
-    "@docusaurus/utils-common" "3.3.2"
-    "@docusaurus/utils-validation" "3.3.2"
+    "@docusaurus/core" "3.4.0"
+    "@docusaurus/mdx-loader" "3.4.0"
+    "@docusaurus/module-type-aliases" "3.4.0"
+    "@docusaurus/plugin-content-blog" "3.4.0"
+    "@docusaurus/plugin-content-docs" "3.4.0"
+    "@docusaurus/plugin-content-pages" "3.4.0"
+    "@docusaurus/theme-common" "3.4.0"
+    "@docusaurus/theme-translations" "3.4.0"
+    "@docusaurus/types" "3.4.0"
+    "@docusaurus/utils" "3.4.0"
+    "@docusaurus/utils-common" "3.4.0"
+    "@docusaurus/utils-validation" "3.4.0"
     "@mdx-js/react" "^3.0.0"
     clsx "^2.0.0"
     copy-text-to-clipboard "^3.2.0"
@@ -2350,18 +2507,18 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-common@3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-3.3.2.tgz#26f8a6d26ea6c297350887f614c6dac73c2ede4a"
-  integrity sha512-kXqSaL/sQqo4uAMQ4fHnvRZrH45Xz2OdJ3ABXDS7YVGPSDTBC8cLebFrRR4YF9EowUHto1UC/EIklJZQMG/usA==
+"@docusaurus/theme-common@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-3.4.0.tgz#01f2b728de6cb57f6443f52fc30675cf12a5d49f"
+  integrity sha512-0A27alXuv7ZdCg28oPE8nH/Iz73/IUejVaCazqu9elS4ypjiLhK3KfzdSQBnL/g7YfHSlymZKdiOHEo8fJ0qMA==
   dependencies:
-    "@docusaurus/mdx-loader" "3.3.2"
-    "@docusaurus/module-type-aliases" "3.3.2"
-    "@docusaurus/plugin-content-blog" "3.3.2"
-    "@docusaurus/plugin-content-docs" "3.3.2"
-    "@docusaurus/plugin-content-pages" "3.3.2"
-    "@docusaurus/utils" "3.3.2"
-    "@docusaurus/utils-common" "3.3.2"
+    "@docusaurus/mdx-loader" "3.4.0"
+    "@docusaurus/module-type-aliases" "3.4.0"
+    "@docusaurus/plugin-content-blog" "3.4.0"
+    "@docusaurus/plugin-content-docs" "3.4.0"
+    "@docusaurus/plugin-content-pages" "3.4.0"
+    "@docusaurus/utils" "3.4.0"
+    "@docusaurus/utils-common" "3.4.0"
     "@types/history" "^4.7.11"
     "@types/react" "*"
     "@types/react-router-config" "*"
@@ -2371,32 +2528,32 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-mermaid@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-mermaid/-/theme-mermaid-3.3.2.tgz#55f385cb79838f12cdc98965bcf4e6dd788c5398"
-  integrity sha512-JY6q7owe5S5iH2N9oTjNDkqmuPW/+4j/zrX46Xag4RYOzt+WtMkeJilbzak8QGG8I2wDJXjUvX7Lu/jWuDAwUg==
+"@docusaurus/theme-mermaid@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-mermaid/-/theme-mermaid-3.4.0.tgz#ef1d2231d0858767f67538b4fafd7d0ce2a3e845"
+  integrity sha512-3w5QW0HEZ2O6x2w6lU3ZvOe1gNXP2HIoKDMJBil1VmLBc9PmpAG17VmfhI/p3L2etNmOiVs5GgniUqvn8AFEGQ==
   dependencies:
-    "@docusaurus/core" "3.3.2"
-    "@docusaurus/module-type-aliases" "3.3.2"
-    "@docusaurus/theme-common" "3.3.2"
-    "@docusaurus/types" "3.3.2"
-    "@docusaurus/utils-validation" "3.3.2"
+    "@docusaurus/core" "3.4.0"
+    "@docusaurus/module-type-aliases" "3.4.0"
+    "@docusaurus/theme-common" "3.4.0"
+    "@docusaurus/types" "3.4.0"
+    "@docusaurus/utils-validation" "3.4.0"
     mermaid "^10.4.0"
     tslib "^2.6.0"
 
-"@docusaurus/theme-search-algolia@3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.3.2.tgz#fe669e756697a2ca79784052e26c43a07ea7e449"
-  integrity sha512-qLkfCl29VNBnF1MWiL9IyOQaHxUvicZp69hISyq/xMsNvFKHFOaOfk9xezYod2Q9xx3xxUh9t/QPigIei2tX4w==
+"@docusaurus/theme-search-algolia@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.4.0.tgz#c499bad71d668df0d0f15b0e5e33e2fc4e330fcc"
+  integrity sha512-aiHFx7OCw4Wck1z6IoShVdUWIjntC8FHCw9c5dR8r3q4Ynh+zkS8y2eFFunN/DL6RXPzpnvKCg3vhLQYJDmT9Q==
   dependencies:
     "@docsearch/react" "^3.5.2"
-    "@docusaurus/core" "3.3.2"
-    "@docusaurus/logger" "3.3.2"
-    "@docusaurus/plugin-content-docs" "3.3.2"
-    "@docusaurus/theme-common" "3.3.2"
-    "@docusaurus/theme-translations" "3.3.2"
-    "@docusaurus/utils" "3.3.2"
-    "@docusaurus/utils-validation" "3.3.2"
+    "@docusaurus/core" "3.4.0"
+    "@docusaurus/logger" "3.4.0"
+    "@docusaurus/plugin-content-docs" "3.4.0"
+    "@docusaurus/theme-common" "3.4.0"
+    "@docusaurus/theme-translations" "3.4.0"
+    "@docusaurus/utils" "3.4.0"
+    "@docusaurus/utils-validation" "3.4.0"
     algoliasearch "^4.18.0"
     algoliasearch-helper "^3.13.3"
     clsx "^2.0.0"
@@ -2406,7 +2563,15 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-translations@3.3.2", "@docusaurus/theme-translations@^2 || ^3":
+"@docusaurus/theme-translations@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-translations/-/theme-translations-3.4.0.tgz#e6355d01352886c67e38e848b2542582ea3070af"
+  integrity sha512-zSxCSpmQCCdQU5Q4CnX/ID8CSUUI3fvmq4hU/GNP/XoAWtXo9SAVnM3TzpU8Gb//H3WCsT8mJcTfyOk3d9ftNg==
+  dependencies:
+    fs-extra "^11.1.1"
+    tslib "^2.6.0"
+
+"@docusaurus/theme-translations@^2 || ^3":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/theme-translations/-/theme-translations-3.3.2.tgz#39ad011573ce963f1eda98ded925971ca57c5a52"
   integrity sha512-bPuiUG7Z8sNpGuTdGnmKl/oIPeTwKr0AXLGu9KaP6+UFfRZiyWbWE87ti97RrevB2ffojEdvchNujparR3jEZQ==
@@ -2414,10 +2579,25 @@
     fs-extra "^11.1.1"
     tslib "^2.6.0"
 
-"@docusaurus/types@3.3.2", "@docusaurus/types@^3.3.2":
+"@docusaurus/types@3.3.2":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-3.3.2.tgz#0e17689512b22209a98f22ee80ac56899e94d390"
   integrity sha512-5p201S7AZhliRxTU7uMKtSsoC8mgPA9bs9b5NQg1IRdRxJfflursXNVsgc3PcMqiUTul/v1s3k3rXXFlRE890w==
+  dependencies:
+    "@mdx-js/mdx" "^3.0.0"
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
+    commander "^5.1.0"
+    joi "^17.9.2"
+    react-helmet-async "^1.3.0"
+    utility-types "^3.10.0"
+    webpack "^5.88.1"
+    webpack-merge "^5.9.0"
+
+"@docusaurus/types@3.4.0", "@docusaurus/types@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-3.4.0.tgz#237c3f737e9db3f7c1a5935a3ef48d6eadde8292"
+  integrity sha512-4jcDO8kXi5Cf9TcyikB/yKmz14f2RZ2qTRerbHAsS+5InE9ZgSLBNLsewtFTcTOXSVcbU3FoGOzcNWAmU1TR0A==
   dependencies:
     "@mdx-js/mdx" "^3.0.0"
     "@types/history" "^4.7.11"
@@ -2436,7 +2616,14 @@
   dependencies:
     tslib "^2.6.0"
 
-"@docusaurus/utils-validation@3.3.2", "@docusaurus/utils-validation@^2 || ^3", "@docusaurus/utils-validation@^3.3.2":
+"@docusaurus/utils-common@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-common/-/utils-common-3.4.0.tgz#2a43fefd35b85ab9fcc6833187e66c15f8bfbbc6"
+  integrity sha512-NVx54Wr4rCEKsjOH5QEVvxIqVvm+9kh7q8aYTU5WzUU9/Hctd6aTrcZ3G0Id4zYJ+AeaG5K5qHA4CY5Kcm2iyQ==
+  dependencies:
+    tslib "^2.6.0"
+
+"@docusaurus/utils-validation@3.3.2", "@docusaurus/utils-validation@^2 || ^3":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-3.3.2.tgz#7109888d9c9b23eec787b41341809438f54c2aec"
   integrity sha512-itDgFs5+cbW9REuC7NdXals4V6++KifgVMzoGOOOSIifBQw+8ULhy86u5e1lnptVL0sv8oAjq2alO7I40GR7pA==
@@ -2446,6 +2633,20 @@
     "@docusaurus/utils-common" "3.3.2"
     joi "^17.9.2"
     js-yaml "^4.1.0"
+    tslib "^2.6.0"
+
+"@docusaurus/utils-validation@3.4.0", "@docusaurus/utils-validation@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz#0176f6e503ff45f4390ec2ecb69550f55e0b5eb7"
+  integrity sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==
+  dependencies:
+    "@docusaurus/logger" "3.4.0"
+    "@docusaurus/utils" "3.4.0"
+    "@docusaurus/utils-common" "3.4.0"
+    fs-extra "^11.2.0"
+    joi "^17.9.2"
+    js-yaml "^4.1.0"
+    lodash "^4.17.21"
     tslib "^2.6.0"
 
 "@docusaurus/utils@3.3.2", "@docusaurus/utils@^2 || ^3":
@@ -2471,6 +2672,32 @@
     shelljs "^0.8.5"
     tslib "^2.6.0"
     url-loader "^4.1.1"
+    webpack "^5.88.1"
+
+"@docusaurus/utils@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-3.4.0.tgz#c508e20627b7a55e2b541e4a28c95e0637d6a204"
+  integrity sha512-fRwnu3L3nnWaXOgs88BVBmG1yGjcQqZNHG+vInhEa2Sz2oQB+ZjbEMO5Rh9ePFpZ0YDiDUhpaVjwmS+AU2F14g==
+  dependencies:
+    "@docusaurus/logger" "3.4.0"
+    "@docusaurus/utils-common" "3.4.0"
+    "@svgr/webpack" "^8.1.0"
+    escape-string-regexp "^4.0.0"
+    file-loader "^6.2.0"
+    fs-extra "^11.1.1"
+    github-slugger "^1.5.0"
+    globby "^11.1.0"
+    gray-matter "^4.0.3"
+    jiti "^1.20.0"
+    js-yaml "^4.1.0"
+    lodash "^4.17.21"
+    micromatch "^4.0.5"
+    prompts "^2.4.2"
+    resolve-pathname "^3.0.0"
+    shelljs "^0.8.5"
+    tslib "^2.6.0"
+    url-loader "^4.1.1"
+    utility-types "^3.10.0"
     webpack "^5.88.1"
 
 "@easyops-cn/autocomplete.js@^0.38.1":
@@ -5561,7 +5788,7 @@ fs-extra@^10.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^11.1.1:
+fs-extra@^11.1.1, fs-extra@^11.2.0:
   version "11.2.0"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz"
   integrity sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==


### PR DESCRIPTION
- Added new GA4 ID to test; docs also use GTM and so ID might be superfluous. 
- upgrade to Docusaurus 3.4.0 from 3.2.