### PR TITLE
updated the editURL to point to the web UI

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -57,7 +57,7 @@ const getConfig = async () => {
             // Please change this to your repo.
             // Remove this to remove the "edit this page" links.
             editUrl:
-              'https://github.dev/tableau/extensions-api/blob/main/website/',
+              'https://github.com/tableau/extensions-api/blob/gh-pages-dev/website',
             remarkPlugins: [remarkDefList],
             sidebarCollapsed: true,
           },


### PR DESCRIPTION
The Edit this Page link now goes to the proper page in the `gh-pages-dev` branch.
`'https://github.com/tableau/extensions-api/blob/gh-pages-dev/website'`
The link goes to the GitHub web UI, and not the VS Code browser extension (`github.dev`). 
When using `github.dev` in the URL, the link always went to the `main` branch instead of the branch in the URL. 
`'https://github.dev/tableau/extensions-api/blob/gh-pages-dev/website'`