### PR TITLE
Doc fix for viz extensions encoding icons; add known issue about duplicate identifiers

### DIFF
--- a/website/docs/dashext/trex_manifest.md
+++ b/website/docs/dashext/trex_manifest.md
@@ -15,6 +15,12 @@ To create a new manifest file (`.trex`) for your extension the easy way, use the
 
 The versioning of the manifest is designed to be semantically simple and support compatibility. The version follows the [Major].[Minor] format. Minor upgrades are backwards compatible while major upgrades involve breaking changes.
 
+:::note
+
+Each extension must be uniquely identified. If multiple extensions in a workbook share the same combination of URL, ID, and version number, the extension zones will not load properly. As a best practice, use unique identifiers for each viz or dashboard extension when creating the manifest file (.trex). For example, for dashboard extensions, make sure that the same `<dashboard-extension>` `id` and `extension-version`, and the `<source-location>` `url` aren't all used together in other extensions.
+
+:::
+
 ## Error Reporting
 
 At start up, Tableau checks the manifest file. If any errors are found while parsing the file, Tableau writes these errors to the `log.txt` file in the `My Tableau Repository/Logs` folder. This is the same location that Tableau Desktop uses to report other errors and activity.

--- a/website/docs/trex_known_issues.md
+++ b/website/docs/trex_known_issues.md
@@ -8,18 +8,29 @@ The following section describes some issues in the current release of the Extens
 For information about what is new or has changed in each release, see the [Release Notes for the Tableau Extensions API](./trex_release-notes.md).
 
 
+### Extensions that share the same identifiers will not load properly
+
+Each extension must be uniquely identified. If multiple extensions in a workbook share the same combination of URL, ID, and version number, the extension zones will not load properly. As a best practice, use unique identifiers for each viz or dashboard extension when creating the manifest file (.trex).
+
+---
+
 ### Tableau Viz - Known Issues
 
 Tableau Viz provides a way to create visualizations in dashboard extensions. The following is a list of issues with the current release of Tableau Viz.
 
 * The vertical header text appears slightly cropped in the SVG output.
-* Tableau fonts are not available in the SVG output.
+* Tableau fonts aren't available in the SVG output.
 
 For information about Tableau Viz, see [Add Tableau Viz to Your Dashboard Extension](./core/trex_tableau_viz.md).
+
+---
 
 ### Unable to debug extensions using Chrome version 80 or later
 
 Because of incompatibilities between Chrome and the internal Chromium-based browser used in Tableau, you can't use Chrome version 80 or later to debug your extensions. If you are using Tableau Desktop 2019.1 or later, you can debug extensions using Chrome version 79 or Chromium version 79. If you are using Tableau Desktop versions 2018.2 or 2018.3, you can use Chromium version 47. For more information about debugging extensions and using the Chromium browser, see [Debug Extensions in Tableau Desktop](./debug/trex_debugging.md) and [Download the Chromium Browser](./debug/trex_debugging.md#download-the-chromium-browser).
+
+
+---
 
 ### Unable to run dashboard extension using self-signed certificates {#unable_self_signed_cert}
 
@@ -36,30 +47,43 @@ You can avoid these errors if you specify the `subjectAlternativeName` (SAN) in 
 
 For more information, see [Google Chromium Enterprise Known Issues - Error "Subject Alternative Name Missing"](https://support.google.com/chrome/a/answer/9813310?hl=en#zippy=%2Cerror-subject-alternative-name-missing-or-neterr-cert-common-name-invalid-or-your-connection-is-not-private) and the following discussion on Stack Overflow: [Invalid self signed SSL cert - “Subject Alternative Name Missing” on StackOverflow](https://stackoverflow.com/questions/43665243/invalid-self-signed-ssl-cert-subject-alternative-name-missing).
 
+---
+
 ### Time zone not persisted when updating date parameter
 
 When you update a date or date-time parameter using `changeValueAsync()`, the time zone information is not kept. The date/time is still correct, however, it is just that the data/time is converted to UTC.
+
+---
 
 ### The getDataSourcesAsync method is slow
 
 If your extension uses the `getDataSourcesAsync()` method, calling this method might negatively impact performance and responsiveness of the viz that your extension is added to. The method is not entirely asynchronous and includes some serial operations.
 
+---
+
 ### Unable to print or save image of the extension in a dashboard
 
 * If you print a dashboard to a `.pdf` file, or save the dashboard as an image (or receive an image of the dashboard, as part of subscription) the zone that contains the extension will be blank.
+
+---
 
 ### HTML drop-down menus in popup dialog windows
 
 * **Fixed in Tableau 2019.1** HTML drop-down menus in popup dialog windows do not work as expected on MacOS. Users will not be able to select menu items using the mouse. They can select items with the cursor keys. To avoid issues on MacOS, use radio buttons or another method for user selection in the popup dialog.
 
+---
+
 ### Decimal separators in parameters
 
 - Decimal separators in parameters are not handled as expected for some locales. If your operating system locale uses commas for decimal separators, the `parameter.changeValueAsync` function expects a string that uses a comma as the decimal separator; however, the `parameter.currentValue` function will return a string using a period as the decimal separator, regardless of locale settings.
+
+---
 
 ### Full data access and permission errors
 
 When an extension needs full data access and the user does not have full data permission on the workbook, Tableau currently allows the extension to run. However, Tableau will throw a console error when the extension calls `getUnderlyingData()` method. See [Handle full data access and permission errors](./core/trex_getdata.md#handle-full-data-access-and-permission-errors).
 
+---
 
 ### Tableau Extensions API library version 1.0.0
 

--- a/website/docs/vizext/trex_viz_manifest.md
+++ b/website/docs/vizext/trex_viz_manifest.md
@@ -13,6 +13,12 @@ For details about a manifest or its fields, see the [Sample Manifest File](#samp
 
 The versioning of the manifest is designed to be semantically simple and support compatibility. The version follows the [Major].[Minor] format. Minor upgrades are backwards compatible while major upgrades involve breaking changes.
 
+:::note
+
+Each extension must be uniquely identified. If multiple extensions in a workbook share the same combination of URL, ID, and version number, the extension zones will not load properly. As a best practice, use unique identifiers for each viz or dashboard extension when creating the manifest file (.trex). For example, for viz extensions, make sure that the same `<worksheet-extension>` `id` and `extension-version`, and the `<source-location>` `url` aren't all used in other extensions.
+
+:::
+
 ## Error Reporting
 
 At start up, Tableau checks the manifest file. If any errors are found while parsing the file, Tableau writes these errors to the `log.txt` file in the `My Tableau Repository/Logs` folder. This is the same location that Tableau Desktop uses to report other errors and activity.
@@ -262,13 +268,32 @@ The following table lists the elements and values you can use to add encoding ti
 
 ## Icons
 
-Custom encodings can be assigned a specific icon by using the <code>&lt;encoding-icon&gt;</code> XML tag inside each <code>&lt;extension&gt;</code> entry in the `.trex` manifest file.
+Custom encodings can be assigned a specific icon by using the <code>&lt;encoding-icon&gt;</code> XML tag inside each <code>&lt;encoding&gt;</code> entry in the `.trex` manifest file.
 
 ```xml
 
 <encoding-icon token="letter-x" />
 
 ```
+
+Note that the `<encoding-icon>` keywords ("`letter-x`", for example) are ids in Tableau associated with specific icons. You should define your own friendly encoding names using the `<display-name>` tag. To help your users, the names you choose for the encoding icons should be related to the viz extension and viz type you are creating. For example, the following snippet uses the encoding icon `token="edge"` (<MarkEdgeIconSvg alt="edge primitive"/>), but labels the icon "Link" to reflect its role in a Sankey visualization.
+
+```xml
+
+<encoding id="edge">
+  <display-name resource-id="edge-id">Link</display-name>
+  <role-spec>
+    <role-type>continuous-measure</role-type>
+    <role-type>continuous-dimension</role-type>
+  </role-spec>
+  <fields max-count="1"/>
+  <encoding-icon token="edge" />
+  <tooltip resource-id="edge-id">Edge</tooltip>
+</encoding>
+
+```
+
+
 
 import MarkColorIconSvg from '../assets/icons/MarkColorIcon_16px.svg';
 import LetterAIconSvg from '../assets/icons/LetterAIcon_16px.svg';
@@ -280,6 +305,7 @@ import MarkLineTypeIconSvg from '../assets/icons/MarkLineTypeIcon_16px.svg';
 import LetterDIconSvg from '../assets/icons/LetterDIcon_16px.svg';
 import MarkShapeBaseIconSvg from '../assets/icons/MarkShapeBaseIcon_16px.svg';
 import LetterEIconSvg from '../assets/icons/LetterEIcon_16px.svg';
+import LetterFIconSvg from '../assets/icons/LetterFIcon_16px.svg';
 import MarkAngleBaseIconSvg from '../assets/icons/MarkAngleBaseIcon_16px.svg';
 import DetailBaseIconSvg from '../assets/icons/DetailBaseIcon_16px.svg';
 import LetterZIconSvg from '../assets/icons/LetterZIcon_16px.svg';
@@ -330,9 +356,8 @@ import NavigationArrowRightIconSvg from '../assets/icons/NavigationArrowRightIco
 import ThumbnailEvenIconSvg from '../assets/icons/ThumbnailEvenIcon_16px.svg';
 
 
-
-
-The following table shows the list of icons you can use.
+The table shows the list of icons you can use. 
+Note that the icons and keywords for the letters "f" through "y" follow the same pattern as the other letters (`token="letter-f"` <LetterFIconSvg alt="letter f"/>). For brevity, they aren't shown in this table.
 
 <table>
 <colgroup>
@@ -388,14 +413,14 @@ The following table shows the list of icons you can use.
 <td><LetterEIconSvg alt="letter e"/></td>
 </tr>
 <tr class="odd">
-<td>angle</td>
+<td>wedge</td>
 <td><MarkAngleBaseIconSvg alt="angle primitive"/></td>
 <td>&nbsp;</td>
 <td>...</td>
 <td>..</td>
 </tr>
 <tr class="odd">
-<td>detail</td>
+<td>level-of-detail</td>
 <td><DetailBaseIconSvg alt="detail primitive"/></td>
 <td>&nbsp;</td>
 <td>letter-z</td>


### PR DESCRIPTION
* corrected the encoding icons ([W-18452616]
* added a note about extensions using the same URL, ids, and version number ([W-18455977]