### PR TITLE
Update CODEOWNERS with proper code for OSS projects

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
-#ECCN:EAR99
+# Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
+#ECCN:Open Source
 #GUSINFO:Open Source,Open Source Workflow


### PR DESCRIPTION
Per internal discussion, we should just tag with 'Open Source' now.